### PR TITLE
Box v0.4.0 Release

### DIFF
--- a/archive/map.main.cpp
+++ b/archive/map.main.cpp
@@ -1,0 +1,31 @@
+#include <box.hpp>
+#include <iostream>
+
+auto square = [](const auto& x) { return x * x; };
+
+auto main() -> int
+{
+    auto xor_3 = [](const auto& x) { return x ^ 3; };
+
+    cortex::box<int> bx { { 0, 1 }
+                        , { 2, 3 }
+                        , { 4, 5 }
+                        , { 6, 7 }
+                        , { 8, 9 } };
+
+    for(auto& x : bx)
+        std::cout << x << ", ";
+    std::cout << std::endl;
+
+    auto ibx { bx.map(square) };
+
+    for(auto& x : ibx)
+        std::cout << x << ", ";
+    std::cout << std::endl;
+
+    auto rbx { ibx.map(xor_3) };
+
+    for(auto& x : rbx)
+        std::cout << x << ", ";
+    std::cout << std::endl;
+}

--- a/package.json5
+++ b/package.json5
@@ -1,6 +1,6 @@
 {
     name: 'cortex-box',
-    version: '0.3.0',
+    version: '0.4.0',
     namespace: 'cortex',
     test_driver: 'Catch-Main',
     depends: [

--- a/package.json5
+++ b/package.json5
@@ -5,6 +5,6 @@
     test_driver: 'Catch-Main',
     depends: [
         'cortex-iterators^0.4.1',
-        'cortex-concepts^0.2.0'
+        'cortex-concepts^0.2.1'
     ]
 }

--- a/package.json5
+++ b/package.json5
@@ -5,6 +5,6 @@
     test_driver: 'Catch-Main',
     depends: [
         'cortex-iterators^0.4.1',
-        'cortex-concepts^0.1.1'
+        'cortex-concepts^0.2.0'
     ]
 }

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -3,7 +3,7 @@
 /// @file box
 /// @author Tyler Swann (oraqlle@github.com)
 /// @brief Two Dimensional Access To Contiguous Data
-/// @version 2.0.6 ..
+/// @version 2.0.7 ..
 /// @date 2022-16-22
 ///
 /// @copyright Copyright (c) 2022
@@ -1704,7 +1704,8 @@ namespace cortex
         /// @    requires BitNot<value_type>
         ///
         /// @return box<~value_type>
-        constexpr auto bit_not() const     requires BitNot<value_type>
+        constexpr auto bit_not() const
+            requires BitNot<value_type>
         {
             if (empty())
                 throw std::invalid_argument("In box::bit_not - bit_not on empty box");
@@ -2345,6 +2346,23 @@ namespace cortex
         else
             lx = lx.sub(rx);
     }
+
+
+    /// @brief 
+    /// 
+    /// @tparam _ElemT 
+    /// @param bx 
+    /// @return constexpr auto 
+    template<BitNot _ElemT>
+    constexpr auto
+    operator~ (box<_ElemT> bx)
+    { return bx.bit_not(); }
+
+
+    template<Any _ElemT>
+    constexpr auto
+    operator! (box<_ElemT> bx)
+    { return bx.transpose(); }
 
 } // namespace cortex
 

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -2784,6 +2784,188 @@ namespace cortex
     }
 
 
+    /// @brief Left Bit Shift Operator
+    ///
+    /// @detail Operator overload for `<<` operator.
+    /// Calls lx `shift_left` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires LeftBitShiftWith<_LxT, _RxT>
+    constexpr auto
+    operator<< (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.shift_left(rx); }
+
+
+    /// @brief Left Bit Shift Operator
+    ///
+    /// @details Operator overload for `<<` operator.
+    /// Calls bx `shift_left` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires LeftBitShiftWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator<< (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.shift_left(sx); }
+
+
+    /// @brief Left Bit Shift Assignment Operator
+    ///
+    /// @detail Operator overload for `<<=` operator.
+    /// Calls lx `shift_left` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `shift_left`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires LeftBitShiftWith<_LxT, _RxT>
+    constexpr void
+    operator<<= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().shift_left(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `shift_left`.");
+        else
+            lx = lx.shift_left(rx);
+    }
+
+
+    /// @brief Left Bit Shift Assignment Operator
+    /// 
+    /// @details Operator overload for `<<=` operator.
+    /// Calls bx `shift_left` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires LeftBitShiftWith<_ElemT, _ScalarT>
+    constexpr void
+    operator<<= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().shift_left(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `shift_left`.");
+        else
+            bx = bx.shift_left(sx);
+    }
+
+
+    /// @brief Right Bit Shift Operator
+    ///
+    /// @detail Operator overload for `>>` operator.
+    /// Calls lx `shift_right` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires RightBitShiftWith<_LxT, _RxT>
+    constexpr auto
+    operator>> (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.shift_right(rx); }
+
+
+    /// @brief Right Bit Shift Operator
+    ///
+    /// @details Operator overload for `>>` operator.
+    /// Calls bx `shift_right` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires RightBitShiftWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator>> (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.shift_right(sx); }
+
+
+    /// @brief Right Bit Shift Assignment Operator
+    ///
+    /// @detail Operator overload for `>>=` operator.
+    /// Calls lx `shift_right` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The right-hand-side box is mutable.
+    /// @note The right-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `shift_right`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires RightBitShiftWith<_LxT, _RxT>
+    constexpr void
+    operator>>= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().shift_right(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: right-hand-side box type cannot store the resulting type of the call to `shift_right`.");
+        else
+            lx = lx.shift_right(rx);
+    }
+
+
+    /// @brief Right Bit Shift Assignment Operator
+    /// 
+    /// @details Operator overload for `>>=` operator.
+    /// Calls bx `shift_right` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The right-hand-side box is mutable.
+    /// @note The right-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires RightBitShiftWith<_ElemT, _ScalarT>
+    constexpr void
+    operator>>= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().shift_right(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: right-hand-side box type cannot store the resulting type of the call to `shift_right`.");
+        else
+            bx = bx.shift_right(sx);
+    }
+
+
     /// @brief Bitwise Not Operator
     ///
     /// @details Operator overload for `~` operator.

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -3,7 +3,7 @@
 /// @file box
 /// @author Tyler Swann (oraqlle@github.com)
 /// @brief Two Dimensional Access To Contiguous Data
-/// @version 2.0.5 ..
+/// @version 2.0.6 ..
 /// @date 2022-16-22
 ///
 /// @copyright Copyright (c) 2022
@@ -1183,8 +1183,8 @@ namespace cortex
         /// `AddableWith` with type of the elemnts of the
         /// passed box. A new box is created and returned.
         ///
-        /// @requires The type of this box's elements are `Addable`
-        /// @requires The type of this box's elements and the type
+        /// @    requires The type of this box's elements are `Addable`
+        /// @    requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `AddableWith`.
         ///
         /// @tparam _ElemT
@@ -1192,7 +1192,7 @@ namespace cortex
         /// @return constexpr auto : A box whose element's type
         /// is the sum of the two input matrices element types.
         template <Addable _ElemT>
-        requires AddableWith<value_type, _ElemT>
+            requires AddableWith<value_type, _ElemT>
         constexpr auto add(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() + std::declval<_ElemT>())>
         {
@@ -1216,8 +1216,8 @@ namespace cortex
         /// of the passed box. A new box is created and
         /// returned.
         ///
-        /// @requires The type of this box's elements are `Subtractable`
-        /// @requires The type of this box's elements and the type
+        /// @    requires The type of this box's elements are `Subtractable`
+        /// @    requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `SubtractableWith`.
         ///
         /// @tparam _ElemT
@@ -1225,7 +1225,7 @@ namespace cortex
         /// @return constexpr auto : A box whose element type
         /// is the difference of the two input matrices element types.
         template <Subtractable _ElemT>
-        requires SubtractableWith<value_type, _ElemT>
+            requires SubtractableWith<value_type, _ElemT>
         constexpr auto sub(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() - std::declval<_ElemT>())>
         {
@@ -1249,8 +1249,8 @@ namespace cortex
         /// of the passed box. A new box is created and
         /// returned.
         ///
-        /// @requires The type of this box's elements are `Multiplicable`
-        /// @requires The type of this box's elements and the type
+        /// @    requires The type of this box's elements are `Multiplicable`
+        /// @    requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `MultiplicableWith`.
         ///
         /// @tparam _ElemT
@@ -1258,7 +1258,7 @@ namespace cortex
         /// @return constexpr auto : A box whose element type
         /// is the product of the two input matrices element types.
         template <Multiplicable _ElemT>
-        requires MultiplicableWith<value_type, _ElemT>
+            requires MultiplicableWith<value_type, _ElemT>
         constexpr auto mul(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() * std::declval<_ElemT>())>
         {
@@ -1277,16 +1277,16 @@ namespace cortex
         /// @details Performs an element-wise multiplication of the box
         /// by a 'scalar' value.
         ///
-        /// @requires The type of this box's elements are `MultiplicableWith`
+        /// @    requires The type of this box's elements are `MultiplicableWith`
         /// the type denoted _ScalarT.
-        /// @requires The type denoted _ScalarT be `Multiplicable`.
+        /// @    requires The type denoted _ScalarT be `Multiplicable`.
         ///
         ///
         /// @tparam _ScalarT
         /// @param scalar type: _ScalarT | qualifiers: [const], [ref]
         /// @return box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
         template <Multiplicable _ScalarT>
-        requires MultiplicableWith<value_type, _ScalarT>
+            requires MultiplicableWith<value_type, _ScalarT>
         constexpr auto mul(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
         {
@@ -1310,8 +1310,8 @@ namespace cortex
         /// of the passed box. A new box is created and
         /// returned.
         ///
-        /// @requires The type of this box's elements are `Divisible`
-        /// @requires The type of this box's elements and the type
+        /// @    requires The type of this box's elements are `Divisible`
+        /// @    requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `DivisibleWith`.
         ///
         /// @note When dividing two matrices, if both matrices elements
@@ -1323,7 +1323,7 @@ namespace cortex
         /// @return constexpr auto : A box whose element type
         /// is the quotient of the two input matrices element types.
         template <Divisible _ElemT>
-        requires DivisibleWith<value_type, _ElemT>
+            requires DivisibleWith<value_type, _ElemT>
         constexpr auto div(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() / std::declval<_ElemT>())>
         {
@@ -1342,9 +1342,9 @@ namespace cortex
         /// @details Performs an element-wise division of the box
         /// by a 'scalar' value.
         ///
-        /// @requires The type of this box's elements are `DivisibleWith`
+        /// @    requires The type of this box's elements are `DivisibleWith`
         /// the type denoted _ScalarT.
-        /// @requires The type denoted _ScalarT be `Divisible`.
+        /// @    requires The type denoted _ScalarT be `Divisible`.
         ///
         /// @note When dividing two matrices, if both matrices elements
         /// are integrals, the division is performed as integer divisionbx.
@@ -1354,7 +1354,7 @@ namespace cortex
         /// @param scalar type: _ScalarT | qualifiers: [const], [ref]
         /// @return box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
         template <Divisible _ScalarT>
-        requires DivisibleWith<value_type, _ScalarT>
+            requires DivisibleWith<value_type, _ScalarT>
         constexpr auto div(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
         {
@@ -1378,11 +1378,11 @@ namespace cortex
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
         ///
-        /// @tparam _ElemT concept: Modulo | requires: ModuloWith<value_type, _ElemT>
+        /// @tparam _ElemT concept: Modulo |     requires: ModuloWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
         template <Modulo _ElemT>
-        requires ModuloWith<value_type, _ElemT>
+            requires ModuloWith<value_type, _ElemT>
         constexpr auto mod(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
         {
@@ -1405,11 +1405,11 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @tparam _ScalarT concept: Modulo | requires: ModuloWith<value_type, _ScalarT>
+        /// @tparam _ScalarT concept: Modulo |     requires: ModuloWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
         template <Modulo _ScalarT>
-        requires ModuloWith<value_type, _ScalarT>
+            requires ModuloWith<value_type, _ScalarT>
         constexpr auto mod(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
         {
@@ -1431,11 +1431,11 @@ namespace cortex
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
         ///
-        /// @tparam _ElemT concept: BitXor | requires: BitXorWith<value_type, _ElemT>
+        /// @tparam _ElemT concept: BitXor |     requires: BitXorWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
         template <BitXor _ElemT>
-        requires BitXorWith<value_type, _ElemT>
+            requires BitXorWith<value_type, _ElemT>
         constexpr auto bit_xor(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
         {
@@ -1458,11 +1458,11 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @tparam _ScalarT concept: BitXor | requires: BitXorWith<value_type, _ScalarT>
+        /// @tparam _ScalarT concept: BitXor |     requires: BitXorWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
         template <BitXor _ScalarT>
-        requires BitXorWith<value_type, _ScalarT>
+            requires BitXorWith<value_type, _ScalarT>
         constexpr auto bit_xor(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
         {
@@ -1485,11 +1485,11 @@ namespace cortex
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
         ///
-        /// @tparam _ElemT concept: BitAnd | requires: BitAndWith<value_type, _ElemT>
+        /// @tparam _ElemT concept: BitAnd |     requires: BitAndWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
         template <BitAnd _ElemT>
-        requires BitAndWith<value_type, _ElemT>
+            requires BitAndWith<value_type, _ElemT>
         constexpr auto bit_and(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
         {
@@ -1512,11 +1512,11 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @tparam _ScalarT concept: BitAnd | requires: BitAndWith<value_type, _ScalarT>
+        /// @tparam _ScalarT concept: BitAnd |     requires: BitAndWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
         template <BitAnd _ScalarT>
-        requires BitAndWith<value_type, _ScalarT>
+            requires BitAndWith<value_type, _ScalarT>
         constexpr auto bit_and(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
         {
@@ -1539,11 +1539,11 @@ namespace cortex
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
         ///
-        /// @tparam _ElemT concept: BitOr | requires: BitOrWith<value_type, _ElemT>
+        /// @tparam _ElemT concept: BitOr |     requires: BitOrWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
         template <BitOr _ElemT>
-        requires BitOrWith<value_type, _ElemT>
+            requires BitOrWith<value_type, _ElemT>
         constexpr auto bit_or(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
         {
@@ -1566,11 +1566,11 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @tparam _ScalarT concept: BitOr | requires: BitOrWith<value_type, _ScalarT>
+        /// @tparam _ScalarT concept: BitOr |     requires: BitOrWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
         template <BitOr _ScalarT>
-        requires BitOrWith<value_type, _ScalarT>
+            requires BitOrWith<value_type, _ScalarT>
         constexpr auto bit_or(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
         {
@@ -1593,11 +1593,11 @@ namespace cortex
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
         ///
-        /// @tparam _ElemT concept: LeftBitShift | requires: LeftBitShiftWith<value_type, _ElemT>
+        /// @tparam _ElemT concept: LeftBitShift |     requires: LeftBitShiftWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
         template <LeftBitShift _ElemT>
-        requires LeftBitShiftWith<value_type, _ElemT>
+            requires LeftBitShiftWith<value_type, _ElemT>
         constexpr auto shift_left(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
         {
@@ -1620,11 +1620,11 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @tparam _ScalarT concept: LeftBitShift | requires: LeftBitShiftWith<value_type, _ScalarT>
+        /// @tparam _ScalarT concept: LeftBitShift |     requires: LeftBitShiftWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
         template <LeftBitShift _ScalarT>
-        requires LeftBitShiftWith<value_type, _ScalarT>
+            requires LeftBitShiftWith<value_type, _ScalarT>
         constexpr auto shift_left(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
         {
@@ -1647,11 +1647,11 @@ namespace cortex
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
         ///
-        /// @tparam _ElemT concept: RightBitShift | requires: RightBitShiftWith<value_type, _ElemT>
+        /// @tparam _ElemT concept: RightBitShift |     requires: RightBitShiftWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
         template <RightBitShift _ElemT>
-        requires RightBitShiftWith<value_type, _ElemT>
+            requires RightBitShiftWith<value_type, _ElemT>
         constexpr auto shift_right(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
         {
@@ -1674,11 +1674,11 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @tparam _ScalarT concept: RightBitShift | requires: RightBitShiftWith<value_type, _ScalarT>
+        /// @tparam _ScalarT concept: RightBitShift |     requires: RightBitShiftWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
         template <RightBitShift _ScalarT>
-        requires RightBitShiftWith<value_type, _ScalarT>
+            requires RightBitShiftWith<value_type, _ScalarT>
         constexpr auto shift_right(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
         {
@@ -1701,10 +1701,10 @@ namespace cortex
         /// @exception std::invalid_argument If the box is empty,
         /// std::invalid_argument is thrown.
         ///
-        /// @requires BitNot<value_type>
+        /// @    requires BitNot<value_type>
         ///
         /// @return box<~value_type>
-        constexpr auto bit_not() const requires BitNot<value_type>
+        constexpr auto bit_not() const     requires BitNot<value_type>
         {
             if (empty())
                 throw std::invalid_argument("In box::bit_not - bit_not on empty box");
@@ -1847,7 +1847,7 @@ namespace cortex
     /// @details Uses std::equal to compare the matrices.
     /// Takes at least O(n) where n = columns x rows = lhs.end() - lhs.begin()
     ///
-    /// @requires Matrix elements support equality comparison
+    /// @    requires Matrix elements support equality comparison
     /// that converts to a bool
     ///
     /// @exception Operation is has no exception iff the comparison
@@ -1864,7 +1864,7 @@ namespace cortex
     /// @return false
     template <typename _ElemL, typename _ElemR>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemL lhsE, _ElemR rhsE)
+        requires     requires(_ElemL lhsE, _ElemR rhsE)
     {
         {
             lhsE == rhsE
@@ -2011,7 +2011,7 @@ namespace cortex
     /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are equal as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support
+    /// @    requires Comparison of scalar type and box type support
     /// equality comparison that results in a bool.
     ///
     /// @exception Operation is noexcept iff the inequlity comparison
@@ -2024,7 +2024,7 @@ namespace cortex
     /// @return box<bool>
     template <typename _ElemT>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemT lhsE, _ElemT rhsE)
+        requires     requires(_ElemT lhsE, _ElemT rhsE)
     {
         {
             lhsE == rhsE
@@ -2051,7 +2051,7 @@ namespace cortex
     /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are inequal as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support
+    /// @    requires Comparison of scalar type and box type support
     /// inequality comparison that results in a bool.
     ///
     /// @exception Operation is noexcept iff the inequlity comparison
@@ -2064,7 +2064,7 @@ namespace cortex
     /// @return box<bool>
     template <typename _ElemT>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemT lhsE, _ElemT rhsE)
+        requires     requires(_ElemT lhsE, _ElemT rhsE)
     {
         {
             lhsE != rhsE
@@ -2091,7 +2091,7 @@ namespace cortex
     /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are less-than as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support
+    /// @    requires Comparison of scalar type and box type support
     /// less-than comparison that results in a bool.
     ///
     /// @exception Operation is noexcept iff the less-than comparison
@@ -2104,7 +2104,7 @@ namespace cortex
     /// @return box<bool>
     template <typename _ElemT>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemT lhsE, _ElemT rhsE)
+        requires     requires(_ElemT lhsE, _ElemT rhsE)
     {
         {
             lhsE < rhsE
@@ -2131,7 +2131,7 @@ namespace cortex
     /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are greater-than as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support
+    /// @    requires Comparison of scalar type and box type support
     /// greater-than comparison that results in a bool.
     ///
     /// @exception Operation is noexcept iff the greater-than comparison
@@ -2144,7 +2144,7 @@ namespace cortex
     /// @return box<bool>
     template <typename _ElemT>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemT lhsE, _ElemT rhsE)
+        requires     requires(_ElemT lhsE, _ElemT rhsE)
     {
         {
             lhsE > rhsE
@@ -2172,7 +2172,7 @@ namespace cortex
     /// that are less-than-eqaul as true and the everything else as
     /// false.
     ///
-    /// @requires Comparison of scalar type and box type support
+    /// @    requires Comparison of scalar type and box type support
     /// less-than comparison that results in a bool.
     ///
     /// @exception Operation is noexcept iff the less-than-equal comparison
@@ -2185,7 +2185,7 @@ namespace cortex
     /// @return box<bool>
     template <typename _ElemT>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemT lhsE, _ElemT rhsE)
+        requires     requires(_ElemT lhsE, _ElemT rhsE)
     {
         {
             lhsE <= rhsE
@@ -2213,7 +2213,7 @@ namespace cortex
     /// that are greater-than-equal as true and the everything else
     /// as false.
     ///
-    /// @requires Comparison of scalar type and box type support
+    /// @    requires Comparison of scalar type and box type support
     /// greater-than-equal comparison that results in a bool.
     ///
     /// @exception Operation is noexcept iff the greater-than-equal
@@ -2227,7 +2227,7 @@ namespace cortex
     /// @return box<bool>
     template <typename _ElemT>
 #if __cpluscplus >= 202002L
-    requires requires(_ElemT lhsE, _ElemT rhsE)
+        requires     requires(_ElemT lhsE, _ElemT rhsE)
     {
         {
             lhsE >= rhsE
@@ -2261,6 +2261,7 @@ namespace cortex
     /// @param rx type: box<_RxT> | qualifiers: [const, ref]
     /// @return constexpr auto 
     template<typename _LxT, typename _RxT>
+        requires AddableWith<_LxT, _RxT>
     constexpr auto
     operator+ (const box<_LxT>& lx, const box<_RxT>& rx)
     { return lx.add(rx); }
@@ -2286,6 +2287,7 @@ namespace cortex
     /// @param rx type: box<_RxT> | qualifiers: [const, ref]
     /// @return constexpr void
     template<Addable _LxT, Addable _RxT>
+        requires AddableWith<_LxT, _RxT>
     constexpr void
     operator+= (box<_LxT>& lx, const box<_RxT>& rx) 
     { 
@@ -2293,6 +2295,55 @@ namespace cortex
             throw std::invalid_argument("operator+=: left-hand-side box type cannot store the resulting type of the call to `add`.");
         else
             lx = lx.add(rx);
+    }
+
+
+    /// @brief Subtraction Operator
+    ///
+    /// @detail Operator overload for `-` operator.
+    /// Calls lx `sub` method on rx and returns 
+    /// the result. 
+    /// 
+    /// @tparam _LxT 
+    /// @tparam _RxT 
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<typename _LxT, typename _RxT>
+        requires SubtractableWith<_LxT, _RxT>
+    constexpr auto
+    operator- (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.sub(rx); }
+
+
+    /// @brief Subiton Assignment Operator
+    ///
+    /// @details Operator overload for `-=` operator.
+    /// Calls lx `sub` method on rx and assigns the result 
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type but be
+    /// able to to store the resulting type of the
+    /// call to `sub`.
+    ///
+    /// @exception std::invalid_argument Thrown if the left-hand-side
+    /// box cannot store the resulting type of the call to `sub`.
+    /// 
+    /// @tparam _LxT concept: Subtractable
+    /// @tparam _RxT concept: Subtractable
+    /// @param lx type: box<_LxT> | qualifiers: [ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr void
+    template<Subtractable _LxT, Subtractable _RxT>
+        requires SubtractableWith<_LxT, _RxT>
+    constexpr void
+    operator-= (box<_LxT>& lx, const box<_RxT>& rx) 
+    { 
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().sub(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator-=: left-hand-side box type cannot store the resulting type of the call to `sub`.");
+        else
+            lx = lx.sub(rx);
     }
 
 } // namespace cortex

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -3,7 +3,7 @@
 /// @file box
 /// @author Tyler Swann (oraqlle@github.com)
 /// @brief Two Dimensional Access To Contiguous Data
-/// @version 2.0.2
+/// @version 2.0.3 ..
 /// @date 2022-16-22
 /// 
 /// @copyright Copyright (c) 2022
@@ -1426,6 +1426,62 @@ namespace cortex
 
             return result;
         }
+
+
+        /// @brief Box Modulus
+        ///
+        /// @details Performs an element-wise modulus operation
+        /// between two boxes. The boxes must have the same dimensions.
+        ///
+        /// @exception std::invalid_argument If the dimensions of the boxes
+        /// do not match, std::invalid_argument is thrown.
+        /// 
+        /// @tparam _ElemT concept: Modulo | requires: ModuloWith<value_type, _ElemT>
+        /// @param other type: box<_ElemT> | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() % std::declval<_ElemT>())> 
+        template<Modulo _ElemT>
+            requires ModuloWith<value_type, _ElemT>
+        constexpr auto mod(const box<_ElemT>& other)
+            -> box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
+        {
+            if (this->dimensions() not_eq other.dimensions())
+                throw std::invalid_argument("In box::mod - dimensions do not match");
+
+            box<decltype(std::declval<value_type>() % std::declval<_ElemT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, other, result.begin(), std::modulus{});
+
+            return result;
+        }
+
+
+        /// @brief Scalar Box Modulus
+        ///
+        /// @details Performs an element-wise modulus operation
+        /// between all elements of the box and the scalar. The 
+        /// box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown. 
+        /// 
+        /// @tparam _ScalarT concept: Modulo | requires: ModuloWith<value_type, _ScalarT>
+        /// @param scalar type: _ScalarT | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())> 
+        template<Modulo _ScalarT>
+            requires ModuloWith<value_type, _ScalarT>
+        constexpr auto mod(const _ScalarT& scalar)
+            -> box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::mod - scalar modulus on empty box");
+
+            box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), [&](auto& elem){ return elem % scalar; });
+
+            return result;
+        }
+        
 
         /// @brief Matrix Transpose
         ///

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -1295,8 +1295,7 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto &elem)
-                                   { return elem * scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto& elem){ return elem * scalar; });
 
             return result;
         }
@@ -1366,8 +1365,7 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto &elem)
-                                   { return elem / scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto& elem){ return elem / scalar; });
 
             return result;
         }
@@ -1420,8 +1418,7 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto &elem)
-                                   { return elem % scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto& elem){ return elem % scalar; });
 
             return result;
         }
@@ -1474,10 +1471,227 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto &elem) { return elem ^ scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem ^ scalar; });
 
             return result;
         }
+
+
+        /// @brief Box Element-wise Bitwise And
+        ///
+        /// @details Performs an element-wise bitwise And operation
+        /// between two boxes. The boxes must have the same dimensions.
+        ///
+        /// @exception std::invalid_argument If the dimensions of the boxes
+        /// do not match, std::invalid_argument is thrown.
+        ///
+        /// @tparam _ElemT concept: BitAnd | requires: BitAndWith<value_type, _ElemT>
+        /// @param other type: box<_ElemT> | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
+        template <BitAnd _ElemT>
+        requires BitAndWith<value_type, _ElemT>
+        constexpr auto bit_and(const box<_ElemT> &other)
+            -> box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
+        {
+            if (this->dimensions() not_eq other.dimensions())
+                throw std::invalid_argument("In box::bit_and - dimensions do not match");
+
+            box<decltype(std::declval<value_type>() & std::declval<_ElemT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, other, result.begin(), std::bit_and{});
+
+            return result;
+        }
+
+        /// @brief Scalar Bitwise And
+        ///
+        /// @details Performs an element-wise bitwise And operation
+        /// between all elements of the box and the scalar. The
+        /// box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown.
+        ///
+        /// @tparam _ScalarT concept: BitAnd | requires: BitAndWith<value_type, _ScalarT>
+        /// @param scalar type: _ScalarT | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
+        template <BitAnd _ScalarT>
+        requires BitAndWith<value_type, _ScalarT>
+        constexpr auto bit_and(const _ScalarT &scalar)
+            -> box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::bit_and - scalar bit_and on empty box");
+
+            box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem & scalar; });
+
+            return result;
+        }
+
+
+        /// @brief Box Element-wise Bitwise Or
+        ///
+        /// @details Performs an element-wise bitwise Or operation
+        /// between two boxes. The boxes must have the same dimensions.
+        ///
+        /// @exception std::invalid_argument If the dimensions of the boxes
+        /// do not match, std::invalid_argument is thrown.
+        ///
+        /// @tparam _ElemT concept: BitOr | requires: BitOrWith<value_type, _ElemT>
+        /// @param other type: box<_ElemT> | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
+        template <BitOr _ElemT>
+        requires BitOrWith<value_type, _ElemT>
+        constexpr auto bit_or(const box<_ElemT> &other)
+            -> box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
+        {
+            if (this->dimensions() not_eq other.dimensions())
+                throw std::invalid_argument("In box::left_bitshift - dimensions do not match");
+
+            box<decltype(std::declval<value_type>() | std::declval<_ElemT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, other, result.begin(), std::bit_or{});
+
+            return result;
+        }
+
+        /// @brief Scalar Bitwise Or
+        ///
+        /// @details Performs an element-wise bitwise Or operation
+        /// between all elements of the box and the scalar. The
+        /// box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown.
+        ///
+        /// @tparam _ScalarT concept: BitOr | requires: BitOrWith<value_type, _ScalarT>
+        /// @param scalar type: _ScalarT | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
+        template <BitOr _ScalarT>
+        requires BitOrWith<value_type, _ScalarT>
+        constexpr auto bit_or(const _ScalarT &scalar)
+            -> box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::left_bitshift - scalar left_bitshift on empty box");
+
+            box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem | scalar; });
+
+            return result;
+        }
+
+
+        /// @brief Box Element-wise Left Bit-shift
+        ///
+        /// @details Performs an element-wise left bit-shift operation
+        /// between two boxes. The boxes must have the same dimensions.
+        ///
+        /// @exception std::invalid_argument If the dimensions of the boxes
+        /// do not match, std::invalid_argument is thrown.
+        ///
+        /// @tparam _ElemT concept: LeftBitShift | requires: LeftBitShiftWith<value_type, _ElemT>
+        /// @param other type: box<_ElemT> | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
+        template <LeftBitShift _ElemT>
+        requires LeftBitShiftWith<value_type, _ElemT>
+        constexpr auto shift_left(const box<_ElemT> &other)
+            -> box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
+        {
+            if (this->dimensions() not_eq other.dimensions())
+                throw std::invalid_argument("In box::left_bitshift - dimensions do not match");
+
+            box<decltype(std::declval<value_type>() << std::declval<_ElemT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, other, result.begin(), [](auto& this_elem, auto& other_elem) { return this_elem << other_elem; });
+
+            return result;
+        }
+
+        /// @brief Scalar Left bit-shift
+        ///
+        /// @details Performs an element-wise left bit-shift operation
+        /// between all elements of the box and the scalar. The
+        /// box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown.
+        ///
+        /// @tparam _ScalarT concept: LeftBitShift | requires: LeftBitShiftWith<value_type, _ScalarT>
+        /// @param scalar type: _ScalarT | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
+        template <LeftBitShift _ScalarT>
+        requires LeftBitShiftWith<value_type, _ScalarT>
+        constexpr auto shift_left(const _ScalarT &scalar)
+            -> box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::left_bitshift - scalar left_bitshift on empty box");
+
+            box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem << scalar; });
+
+            return result;
+        }
+
+
+        /// @brief Box Element-wise Right Bit-shift
+        ///
+        /// @details Performs an element-wise right bit-shift operation
+        /// between two boxes. The boxes must have the same dimensions.
+        ///
+        /// @exception std::invalid_argument If the dimensions of the boxes
+        /// do not match, std::invalid_argument is thrown.
+        ///
+        /// @tparam _ElemT concept: RightBitShift | requires: RightBitShiftWith<value_type, _ElemT>
+        /// @param other type: box<_ElemT> | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
+        template <RightBitShift _ElemT>
+        requires RightBitShiftWith<value_type, _ElemT>
+        constexpr auto shift_right(const box<_ElemT> &other)
+            -> box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
+        {
+            if (this->dimensions() not_eq other.dimensions())
+                throw std::invalid_argument("In box::right_bitshift - dimensions do not match");
+
+            box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, other, result.begin(), [](auto& this_elem, auto& other_elem) { return this_elem >> other_elem; });
+
+            return result;
+        }
+
+        /// @brief Scalar Right bit-shift
+        ///
+        /// @details Performs an element-wise right bit-shift operation
+        /// between all elements of the box and the scalar. The
+        /// box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown.
+        ///
+        /// @tparam _ScalarT concept: RightBitShift | requires: RightBitShiftWith<value_type, _ScalarT>
+        /// @param scalar type: _ScalarT | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
+        template <RightBitShift _ScalarT>
+        requires RightBitShiftWith<value_type, _ScalarT>
+        constexpr auto shift_right(const _ScalarT &scalar)
+            -> box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::right_bitshift - scalar right_bitshift on empty box");
+
+            box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem >> scalar; });
+
+            return result;
+        }
+
 
         /// @brief Matrix Transpose
         ///

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -2439,7 +2439,6 @@ namespace cortex
     /// @note The left-hand-side box is mutable.
     /// @note The left-hand-side boxes type must be
     /// able to to store the resulting type of the
-
     ///
     /// @tparam _ElemT concept: Any
     /// @tparam _ScalarT concept: Any
@@ -2455,6 +2454,333 @@ namespace cortex
             throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `mul`.");
         else
             bx = bx.mul(sx);
+    }
+
+
+    /// @brief Bit And Operator
+    ///
+    /// @detail Operator overload for `&` operator.
+    /// Calls lx `bit_and` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires BitAndWith<_LxT, _RxT>
+    constexpr auto
+    operator& (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.bit_and(rx); }
+
+
+    /// @brief Bit And Operator
+    ///
+    /// @details Operator overload for `&` operator.
+    /// Calls bx `bit_and` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires BitAndWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator& (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.bit_and(sx); }
+
+
+    /// @brief Bit And Operator
+    ///
+    /// @details Operator overload for `&` operator.
+    /// Calls bx `bit_and` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ScalarT concept: Any
+    /// @tparam _ElemT concept: Any
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ScalarT, Any _ElemT>
+        requires BitAndWith<_ScalarT, _ElemT>
+    constexpr auto
+    operator& (const _ScalarT& sx, const box<_ElemT>& bx)
+    { return bx.bit_and(sx); }
+
+
+    /// @brief Bit And Assignment Operator
+    ///
+    /// @detail Operator overload for `&=` operator.
+    /// Calls lx `bit_and` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `bit_and`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires BitAndWith<_LxT, _RxT>
+    constexpr void
+    operator&= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().bit_and(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator&=: left-hand-side box type cannot store the resulting type of the call to `bit_and`.");
+        else
+            lx = lx.bit_and(rx);
+    }
+
+
+    /// @brief Bit And Assignment Operator
+    /// 
+    /// @details Operator overload for `*=` operator.
+    /// Calls bx `bit_and` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires BitAndWith<_ElemT, _ScalarT>
+    constexpr void
+    operator&= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().bit_and(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `bit_and`.");
+        else
+            bx = bx.bit_and(sx);
+    }
+
+
+    /// @brief Bit Or Operator
+    ///
+    /// @detail Operator overload for `*` operator.
+    /// Calls lx `bit_or` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires BitOrWith<_LxT, _RxT>
+    constexpr auto
+    operator| (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.bit_or(rx); }
+
+
+    /// @brief Bit Or Operator
+    ///
+    /// @details Operator overload for `*` operator.
+    /// Calls bx `bit_or` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires BitOrWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator| (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.bit_or(sx); }
+
+
+    /// @brief Bit Or Operator
+    ///
+    /// @details Operator overload for `*` operator.
+    /// Calls bx `bit_or` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ScalarT concept: Any
+    /// @tparam _ElemT concept: Any
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ScalarT, Any _ElemT>
+        requires BitOrWith<_ScalarT, _ElemT>
+    constexpr auto
+    operator| (const _ScalarT& sx, const box<_ElemT>& bx)
+    { return bx.bit_or(sx); }
+
+
+    /// @brief Bit Or Assignment Operator
+    ///
+    /// @detail Operator overload for `*=` operator.
+    /// Calls lx `bit_or` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `bit_or`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires BitOrWith<_LxT, _RxT>
+    constexpr void
+    operator|= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().bit_or(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `bit_or`.");
+        else
+            lx = lx.bit_or(rx);
+    }
+
+
+    /// @brief Bit Or Assignment Operator
+    /// 
+    /// @details Operator overload for `*=` operator.
+    /// Calls bx `bit_or` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires BitOrWith<_ElemT, _ScalarT>
+    constexpr void
+    operator|= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().bit_or(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `bit_or`.");
+        else
+            bx = bx.bit_or(sx);
+    }
+
+
+    /// @brief Bit Xor Operator
+    ///
+    /// @detail Operator overload for `^` operator.
+    /// Calls lx `bit_xor` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires BitXorWith<_LxT, _RxT>
+    constexpr auto
+    operator^ (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.bit_xor(rx); }
+
+
+    /// @brief Bit Xor Operator
+    ///
+    /// @details Operator overload for `^` operator.
+    /// Calls bx `bit_xor` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires BitXorWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator^ (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.bit_xor(sx); }
+
+
+    /// @brief Bit Xor Operator
+    ///
+    /// @details Operator overload for `^` operator.
+    /// Calls bx `bit_xor` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ScalarT concept: Any
+    /// @tparam _ElemT concept: Any
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ScalarT, Any _ElemT>
+        requires BitXorWith<_ScalarT, _ElemT>
+    constexpr auto
+    operator^ (const _ScalarT& sx, const box<_ElemT>& bx)
+    { return bx.bit_xor(sx); }
+
+
+    /// @brief Bit Xor Assignment Operator
+    ///
+    /// @detail Operator overload for `^=` operator.
+    /// Calls lx `bit_xor` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `bit_xor`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires BitXorWith<_LxT, _RxT>
+    constexpr void
+    operator^= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().bit_xor(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `bit_xor`.");
+        else
+            lx = lx.bit_xor(rx);
+    }
+
+
+    /// @brief Bit Xor Assignment Operator
+    /// 
+    /// @details Operator overload for `^=` operator.
+    /// Calls bx `bit_xor` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires BitXorWith<_ElemT, _ScalarT>
+    constexpr void
+    operator^= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().bit_xor(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `bit_xor`.");
+        else
+            bx = bx.bit_xor(sx);
     }
 
 

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -1257,7 +1257,7 @@ namespace cortex
         /// @param other type: box<_ElemT> | qualifiers: [const], [ref]
         /// @return constexpr auto : A box whose element type
         /// is the product of the two input matrices element types.
-        template <Multiplicable _ElemT>
+        template <Any _ElemT>
             requires MultiplicableWith<value_type, _ElemT>
         constexpr auto mul(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() * std::declval<_ElemT>())>
@@ -1285,7 +1285,7 @@ namespace cortex
         /// @tparam _ScalarT
         /// @param scalar type: _ScalarT | qualifiers: [const], [ref]
         /// @return box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
-        template <Multiplicable _ScalarT>
+        template <Any _ScalarT>
             requires MultiplicableWith<value_type, _ScalarT>
         constexpr auto mul(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
@@ -1322,7 +1322,7 @@ namespace cortex
         /// @param other type: box<_ElemT> | qualifiers: [const], [ref]
         /// @return constexpr auto : A box whose element type
         /// is the quotient of the two input matrices element types.
-        template <Divisible _ElemT>
+        template <Any _ElemT>
             requires DivisibleWith<value_type, _ElemT>
         constexpr auto div(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() / std::declval<_ElemT>())>
@@ -1353,7 +1353,7 @@ namespace cortex
         /// @tparam _ScalarT
         /// @param scalar type: _ScalarT | qualifiers: [const], [ref]
         /// @return box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
-        template <Divisible _ScalarT>
+        template <Any _ScalarT>
             requires DivisibleWith<value_type, _ScalarT>
         constexpr auto div(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
@@ -2261,7 +2261,7 @@ namespace cortex
     /// @param lx type: box<_LxT> | qualifiers: [const, ref]
     /// @param rx type: box<_RxT> | qualifiers: [const, ref]
     /// @return constexpr auto 
-    template<typename _LxT, typename _RxT>
+    template<Addable _LxT, Addable _RxT>
         requires AddableWith<_LxT, _RxT>
     constexpr auto
     operator+ (const box<_LxT>& lx, const box<_RxT>& rx)
@@ -2310,14 +2310,14 @@ namespace cortex
     /// @param lx type: box<_LxT> | qualifiers: [const, ref]
     /// @param rx type: box<_RxT> | qualifiers: [const, ref]
     /// @return constexpr auto 
-    template<typename _LxT, typename _RxT>
+    template<Subtractable _LxT, Subtractable _RxT>
         requires SubtractableWith<_LxT, _RxT>
     constexpr auto
     operator- (const box<_LxT>& lx, const box<_RxT>& rx)
     { return lx.sub(rx); }
 
 
-    /// @brief Subiton Assignment Operator
+    /// @brief Subtraction Assignment Operator
     ///
     /// @details Operator overload for `-=` operator.
     /// Calls lx `sub` method on rx and assigns the result 
@@ -2348,10 +2348,124 @@ namespace cortex
     }
 
 
-    /// @brief 
+    /// @brief Multiplication Operator
+    ///
+    /// @detail Operator overload for `*` operator.
+    /// Calls lx `mul` method on rx and returns
+    /// the resulting box.
     /// 
-    /// @tparam _ElemT 
-    /// @param bx 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires MultiplicableWith<_LxT, _RxT>
+    constexpr auto
+    operator* (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.mul(rx); }
+
+
+    /// @brief Multiplication Operator
+    ///
+    /// @details Operator overload for `*` operator.
+    /// Calls bx `mul` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires MultiplicableWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator* (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.mul(sx); }
+
+
+    /// @brief Multiplication Operator
+    ///
+    /// @details Operator overload for `*` operator.
+    /// Calls bx `mul` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ScalarT concept: Any
+    /// @tparam _ElemT concept: Any
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ScalarT, Any _ElemT>
+        requires MultiplicableWith<_ScalarT, _ElemT>
+    constexpr auto
+    operator* (const _ScalarT& sx, const box<_ElemT>& bx)
+    { return bx.mul(sx); }
+
+
+    /// @brief Multiplication Assignment Operator
+    ///
+    /// @detail Operator overload for `*=` operator.
+    /// Calls lx `mul` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `mul`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires MultiplicableWith<_LxT, _RxT>
+    constexpr void
+    operator*= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().mul(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `mul`.");
+        else
+            lx = lx.mul(rx);
+    }
+
+
+    /// @brief Multiplication Assignment Operator
+    /// 
+    /// @details Operator overload for `*=` operator.
+    /// Calls bx `mul` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires MultiplicableWith<_ElemT, _ScalarT>
+    constexpr void
+    operator*= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().mul(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `mul`.");
+        else
+            bx = bx.mul(sx);
+    }
+
+
+    /// @brief Bitwise Not Operator
+    ///
+    /// @details Operator overload for `~` operator.
+    /// Calls bx `bit_not` method and returns the 
+    /// resulting box. 
+    /// 
+    /// @tparam _ElemT : concept: BitNot
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
     /// @return constexpr auto 
     template<BitNot _ElemT>
     constexpr auto
@@ -2359,6 +2473,15 @@ namespace cortex
     { return bx.bit_not(); }
 
 
+    /// @brief Transpose Operator
+    ///
+    /// @details Operator overload for `!` operator.
+    /// Calls bx `transpose` method and returns the
+    /// resulting box. 
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
     template<Any _ElemT>
     constexpr auto
     operator! (box<_ElemT> bx)

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -1548,7 +1548,7 @@ namespace cortex
             -> box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
-                throw std::invalid_argument("In box::left_bitshift - dimensions do not match");
+                throw std::invalid_argument("In box::bit_or - dimensions do not match");
 
             box<decltype(std::declval<value_type>() | std::declval<_ElemT>())> result(this->rows(), this->columns());
 
@@ -1575,7 +1575,7 @@ namespace cortex
             -> box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
         {
             if (empty())
-                throw std::invalid_argument("In box::left_bitshift - scalar left_bitshift on empty box");
+                throw std::invalid_argument("In box::bit_or - scalar bit_or on empty box");
 
             box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
@@ -1602,7 +1602,7 @@ namespace cortex
             -> box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
-                throw std::invalid_argument("In box::left_bitshift - dimensions do not match");
+                throw std::invalid_argument("In box::shift_left - dimensions do not match");
 
             box<decltype(std::declval<value_type>() << std::declval<_ElemT>())> result(this->rows(), this->columns());
 
@@ -1629,7 +1629,7 @@ namespace cortex
             -> box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
         {
             if (empty())
-                throw std::invalid_argument("In box::left_bitshift - scalar left_bitshift on empty box");
+                throw std::invalid_argument("In box::shift_left - scalar shift_left on empty box");
 
             box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
@@ -1656,7 +1656,7 @@ namespace cortex
             -> box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
-                throw std::invalid_argument("In box::right_bitshift - dimensions do not match");
+                throw std::invalid_argument("In box::shift_right - dimensions do not match");
 
             box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())> result(this->rows(), this->columns());
 
@@ -1683,11 +1683,35 @@ namespace cortex
             -> box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
         {
             if (empty())
-                throw std::invalid_argument("In box::right_bitshift - scalar right_bitshift on empty box");
+                throw std::invalid_argument("In box::shift_right - scalar shift_right on empty box");
 
             box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
             std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem >> scalar; });
+
+            return result;
+        }
+
+
+        /// @brief Element-wise Bitwise Not
+        ///
+        /// @details Performs an element-wise bitwise not operation.
+        /// The box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown.
+        ///
+        /// @requires BitNot<value_type>
+        ///
+        /// @return box<~value_type>
+        constexpr auto bit_not() requires BitNot<value_type>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::bit_not - bit_not on empty box");
+
+            box<decltype(~std::declval<value_type>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), std::bit_not{});
 
             return result;
         }

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -2457,6 +2457,188 @@ namespace cortex
     }
 
 
+    /// @brief Division Operator
+    ///
+    /// @detail Operator overload for `/` operator.
+    /// Calls lx `div` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires DivisibleWith<_LxT, _RxT>
+    constexpr auto
+    operator/ (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.div(rx); }
+
+
+    /// @brief Division Operator
+    ///
+    /// @details Operator overload for `/` operator.
+    /// Calls bx `div` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires DivisibleWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator/ (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.div(sx); }
+
+
+    /// @brief Division Assignment Operator
+    ///
+    /// @detail Operator overload for `/=` operator.
+    /// Calls lx `div` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `div`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires DivisibleWith<_LxT, _RxT>
+    constexpr void
+    operator/= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().div(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `div`.");
+        else
+            lx = lx.div(rx);
+    }
+
+
+    /// @brief Division Assignment Operator
+    /// 
+    /// @details Operator overload for `/=` operator.
+    /// Calls bx `div` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires DivisibleWith<_ElemT, _ScalarT>
+    constexpr void
+    operator/= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().div(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `div`.");
+        else
+            bx = bx.div(sx);
+    }
+
+
+    /// @brief Modulo Operator
+    ///
+    /// @detail Operator overload for `%` operator.
+    /// Calls lx `mod` method on rx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<Any _LxT, Any _RxT>
+        requires ModuloWith<_LxT, _RxT>
+    constexpr auto
+    operator% (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.mod(rx); }
+
+
+    /// @brief Modulo Operator
+    ///
+    /// @details Operator overload for `%` operator.
+    /// Calls bx `mod` method on scalar sx and returns
+    /// the resulting box.
+    /// 
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires ModuloWith<_ElemT, _ScalarT>
+    constexpr auto
+    operator% (const box<_ElemT>& bx, const _ScalarT& sx)
+    { return bx.mod(sx); }
+
+
+    /// @brief Modulo Assignment Operator
+    ///
+    /// @detail Operator overload for `%=` operator.
+    /// Calls lx `mod` method on rx and assigns the result
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    /// call to `mod`.
+    /// 
+    /// @tparam _LxT concept: Any
+    /// @tparam _RxT concept: Any
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _LxT, Any _RxT>
+        requires ModuloWith<_LxT, _RxT>
+    constexpr void
+    operator%= (box<_LxT>& lx, const box<_RxT>& rx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().mod(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `mod`.");
+        else
+            lx = lx.mod(rx);
+    }
+
+
+    /// @brief Modulo Assignment Operator
+    /// 
+    /// @details Operator overload for `%=` operator.
+    /// Calls bx `mod` method on scalar sx and assigns 
+    /// the result to bx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type must be
+    /// able to to store the resulting type of the
+    ///
+    /// @tparam _ElemT concept: Any
+    /// @tparam _ScalarT concept: Any
+    /// @param bx type: box<_ElemT> | qualifiers: [const, ref]
+    /// @param sx type: _ScalarT | qualifiers: [const, ref]
+    /// @return requires constexpr 
+    template<Any _ElemT, Any _ScalarT>
+        requires ModuloWith<_ElemT, _ScalarT>
+    constexpr void
+    operator%= (box<_ElemT>& bx, const _ScalarT& sx)
+    {
+        if constexpr (!std::same_as<decltype(std::declval<box<_ElemT>>().mod(std::declval<_ScalarT>())), box<_ElemT>>)
+            throw std::invalid_argument("operator*=: left-hand-side box type cannot store the resulting type of the call to `mod`.");
+        else
+            bx = bx.mod(sx);
+    }
+
+
     /// @brief Bit And Operator
     ///
     /// @detail Operator overload for `&` operator.

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -5,12 +5,11 @@
 /// @brief Two Dimensional Access To Contiguous Data
 /// @version 2.0.3 ..
 /// @date 2022-16-22
-/// 
+///
 /// @copyright Copyright (c) 2022
 
-
 #ifndef CORTEX_BOX_H
-#   define CORTEX_BOX_H 1
+#define CORTEX_BOX_H 1
 
 #include <iterators/normal.hpp>
 #include <iterators/column.hpp>
@@ -26,185 +25,157 @@
 #include <ranges>
 #include <vector>
 #include <execution>
+#include <functional>
 
 #define lexicographical_compare_bug 1
-
 
 namespace cortex
 {
     /// @brief Box - Two Dimensional Array
-    /// 
-    /// @details Box is a two dimensional array that 
-    /// stores elements sequentially in memory but is 
-    /// viewed as a series of rows and columns. 
-    /// 
+    ///
+    /// @details Box is a two dimensional array that
+    /// stores elements sequentially in memory but is
+    /// viewed as a series of rows and columns.
+    ///
     /// @todo Add support for iterator constructors -------------------------- ✔️
     /// @todo Projection method ---------------------------------------------- 🗑️ (do-able with assign)
     /// @todo Add support for single initialiser constructor ----------------- 🗑️ (too ambiguous for compiler)
-    /// @todo Add support for assign ----------------------------------------- 
-    /// @todo Add other modification methods (mod, xor etc.) ----------------- 
-    /// @todo Add support for operator overloads ----------------------------- 
-    /// @todo Add flips ------------------------------------------------------ 
+    /// @todo Add support for assign -----------------------------------------
+    /// @todo Add other modification methods (mod, xor etc.) -----------------
+    /// @todo Add support for operator overloads -----------------------------
+    /// @todo Add flips ------------------------------------------------------
     /// @todo Add rotates ----------------------------------------------------
-    /// 
-    /// @tparam _Tp 
-    template<typename _Tp, typename _Alloc = std::allocator<_Tp>>
+    ///
+    /// @tparam _Tp
+    template <typename _Tp, typename _Alloc = std::allocator<_Tp>>
     class box
     {
     public:
-        using value_type                    = _Tp;
-        using size_type                     = std::size_t;
-        using difference_type               = std::ptrdiff_t;
+        using value_type = _Tp;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
 
-        using allocator_type                = _Alloc;
-        using alloc_traits                  = typename std::allocator_traits<_Alloc>;
+        using allocator_type = _Alloc;
+        using alloc_traits = typename std::allocator_traits<_Alloc>;
 
-        using reference                     = _Tp&;
-        using const_reference               = const _Tp&;
-        using pointer                       = typename alloc_traits::pointer;
-        using const_pointer                 = typename alloc_traits::pointer;
+        using reference = _Tp &;
+        using const_reference = const _Tp &;
+        using pointer = typename alloc_traits::pointer;
+        using const_pointer = typename alloc_traits::pointer;
 
-        using iterator                      = cortex::normal_iterator<pointer, box<value_type>>;
-        using const_iterator                = cortex::normal_iterator<const_pointer, box<value_type>>;
-        using reverse_iterator              = std::reverse_iterator<iterator>;
-        using const_reverse_iterator        = std::reverse_iterator<const_iterator>;
+        using iterator = cortex::normal_iterator<pointer, box<value_type>>;
+        using const_iterator = cortex::normal_iterator<const_pointer, box<value_type>>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-        using column_iterator               = cortex::column_iterator<iterator>;
-        using const_column_iterator         = cortex::column_iterator<const_iterator>;
-        using reverse_column_iterator       = std::reverse_iterator<column_iterator>;
+        using column_iterator = cortex::column_iterator<iterator>;
+        using const_column_iterator = cortex::column_iterator<const_iterator>;
+        using reverse_column_iterator = std::reverse_iterator<column_iterator>;
         using const_reverse_column_iterator = std::reverse_iterator<const_column_iterator>;
 
-        using row_iterator                  = cortex::row_iterator<iterator>;
-        using const_row_iterator            = cortex::row_iterator<const_iterator>;
-        using reverse_row_iterator          = std::reverse_iterator<row_iterator>;
-        using const_reverse_row_iterator    = std::reverse_iterator<const_row_iterator>;
+        using row_iterator = cortex::row_iterator<iterator>;
+        using const_row_iterator = cortex::row_iterator<const_iterator>;
+        using reverse_row_iterator = std::reverse_iterator<row_iterator>;
+        using const_reverse_row_iterator = std::reverse_iterator<const_row_iterator>;
 
+    private:
+        size_type m_rows;
+        size_type m_columns;
 
-    private: 
-            size_type m_rows;
-            size_type m_columns;
-
-            allocator_type m_allocator;
-            pointer m_start;
-            pointer m_finish;
+        allocator_type m_allocator;
+        pointer m_start;
+        pointer m_finish;
 
     public:
-
         /// @brief Default Constructor
-        /// 
+        ///
         /// @details Default constructor for box.
         constexpr box() noexcept
-        : m_rows(size_type())
-        , m_columns(size_type())
-        , m_allocator(allocator_type())
-        , m_start(pointer())
-        , m_finish(pointer())
-        { }
+            : m_rows(size_type()), m_columns(size_type()), m_allocator(allocator_type()), m_start(pointer()), m_finish(pointer())
+        {
+        }
 
-        
         /// @brief Allocator Constructor
         ///
-        /// @details Default Constructs a box with a 
-        /// given allocator. 
+        /// @details Default Constructs a box with a
+        /// given allocator.
         ///
         /// @param alloc type: allocator_type | qualifiers: [const], [ref]
-        constexpr explicit box(const allocator_type& alloc) noexcept
-        : m_rows(size_type())
-        , m_columns(size_type())
-        , m_allocator(alloc)
-        , m_start(pointer())
-        , m_finish(pointer())
-        { }
-
+        constexpr explicit box(const allocator_type &alloc) noexcept
+            : m_rows(size_type()), m_columns(size_type()), m_allocator(alloc), m_start(pointer()), m_finish(pointer())
+        {
+        }
 
         /// @brief Size Constructor
-        /// 
-        /// @details Constructs a box with dimensions of 
-        /// cols x rows. Values are default constructed or 
+        ///
+        /// @details Constructs a box with dimensions of
+        /// cols x rows. Values are default constructed or
         /// fill constructed depending on the default constructiblity
         /// qualificationbx.
-        /// 
+        ///
         /// @param cols type: [size_type]
         /// @param rows type: [size_type]
         /// @param alloc type: [allocator_type] | qualifiers: [const], [ref]
-        constexpr explicit box(size_type rows, size_type cols, const allocator_type& alloc = allocator_type())
-        : m_rows(rows)
-        , m_columns(cols)
-        , m_allocator(alloc)
-        , m_start(_M_allocate(_M_size(m_rows, m_columns)))
-        , m_finish(m_start + _M_size(m_rows, m_columns))
-        { 
+        constexpr explicit box(size_type rows, size_type cols, const allocator_type &alloc = allocator_type())
+            : m_rows(rows), m_columns(cols), m_allocator(alloc), m_start(_M_allocate(_M_size(m_rows, m_columns))), m_finish(m_start + _M_size(m_rows, m_columns))
+        {
             if constexpr (std::is_default_constructible_v<value_type>)
                 std::ranges::uninitialized_default_construct(*this);
             else
                 std::ranges::uninitialized_fill(*this, value_type());
         }
 
-
         /// @brief Size + Value Constructor
-        /// 
+        ///
         /// @details Constructs a box with dimensions of
-        /// cols x rows. Values are constructed from the a 
+        /// cols x rows. Values are constructed from the a
         /// const reference to a provided value.
-        /// 
+        ///
         /// @param cols type: [size_type]
         /// @param rows type: [size_type]
         /// @param value type: [value_type] | qualifiers: [const], [ref]
         /// @param alloc type: [allocator_type] | qualifiers: [const], [ref]
-        constexpr box(size_type rows, size_type cols, const value_type& value, const allocator_type& alloc = allocator_type())
-        : m_rows(rows)
-        , m_columns(cols)
-        , m_allocator(alloc)
-        , m_start(_M_allocate(_M_size(m_rows, m_columns)))
-        , m_finish(m_start + _M_size(m_rows, m_columns))
-        { std::ranges::uninitialized_fill(*this, value); }
-
+        constexpr box(size_type rows, size_type cols, const value_type &value, const allocator_type &alloc = allocator_type())
+            : m_rows(rows), m_columns(cols), m_allocator(alloc), m_start(_M_allocate(_M_size(m_rows, m_columns))), m_finish(m_start + _M_size(m_rows, m_columns))
+        {
+            std::ranges::uninitialized_fill(*this, value);
+        }
 
         /// @brief Copy Constructor
-        /// 
+        ///
         /// @details Constructs a box that is a copy of
         /// another box of the same underlying type.
-        /// 
+        ///
         /// @param other type: [box] | qualifiers: [const], [ref]
-        constexpr box(const box& other)
-        : m_rows(other.m_rows)
-        , m_columns(other.m_columns)
-        , m_allocator(other.m_allocator)
-        , m_start(_M_allocate(_M_size(m_rows, m_columns)))
-        , m_finish(m_start + _M_size(m_rows, m_columns))
-        { std::ranges::uninitialized_copy(other, *this); }
-
+        constexpr box(const box &other)
+            : m_rows(other.m_rows), m_columns(other.m_columns), m_allocator(other.m_allocator), m_start(_M_allocate(_M_size(m_rows, m_columns))), m_finish(m_start + _M_size(m_rows, m_columns))
+        {
+            std::ranges::uninitialized_copy(other, *this);
+        }
 
         /// @brief Copy Constructor with Alternative Allocator
-        /// 
+        ///
         /// @details Constructs a box that is a copy of
         /// another box of the same underlying type.
-        /// 
+        ///
         /// @param other type: [box] | qualifiers: [const], [ref]
         /// @param alloc type: [allocator_type] | qualifiers: [const], [ref]
-        constexpr box(const box& other, const allocator_type& alloc)
-        : m_rows(other.m_rows)
-        , m_columns(other.m_columns)
-        , m_allocator(alloc)
-        , m_start(_M_allocate(_M_size(m_rows, m_columns)))
-        , m_finish(m_start + _M_size(m_rows, m_columns))
-        { std::ranges::uninitialized_copy(other, *this); }
-
+        constexpr box(const box &other, const allocator_type &alloc)
+            : m_rows(other.m_rows), m_columns(other.m_columns), m_allocator(alloc), m_start(_M_allocate(_M_size(m_rows, m_columns))), m_finish(m_start + _M_size(m_rows, m_columns))
+        {
+            std::ranges::uninitialized_copy(other, *this);
+        }
 
         /// @brief Move Constructor
-        /// 
+        ///
         /// @details Moves ownership of an existing box's
         /// resources to this box and leaves the other box
         /// in a default constructed state.
-        /// 
+        ///
         /// @param other type: [box] | qualifiers: [move]
-        constexpr box(box&& other) noexcept
-        : m_rows(other.m_rows)
-        , m_columns(other.m_columns)
-        , m_allocator(std::move(other.m_allocator))
-        , m_start(other.m_start)
-        , m_finish(other.m_finish)
-        { 
+        constexpr box(box &&other) noexcept
+            : m_rows(other.m_rows), m_columns(other.m_columns), m_allocator(std::move(other.m_allocator)), m_start(other.m_start), m_finish(other.m_finish)
+        {
             other.m_start = pointer();
             other.m_finish = pointer();
             other.m_allocator = allocator_type();
@@ -212,22 +183,17 @@ namespace cortex
             other.m_columns = size_type();
         }
 
-
         /// @brief Move Constructor with Alternative Allocator
-        /// 
+        ///
         /// @details Moves ownership of an existing box's
         /// resources to this box and leaves the other box
         /// in a default constructed state.
-        /// 
+        ///
         /// @param other type: [box] | qualifiers: [move]
         /// @param alloc type: [allocator_type] | qualifiers: [const], [ref]
-        constexpr box(box&& other, const allocator_type& alloc) noexcept
-        : m_rows(other.m_rows)
-        , m_columns(other.m_columns)
-        , m_allocator(alloc)
-        , m_start(other.m_start)
-        , m_finish(other.m_finish)
-        { 
+        constexpr box(box &&other, const allocator_type &alloc) noexcept
+            : m_rows(other.m_rows), m_columns(other.m_columns), m_allocator(alloc), m_start(other.m_start), m_finish(other.m_finish)
+        {
             other.m_start = pointer();
             other.m_finish = pointer();
             other.m_allocator = allocator_type();
@@ -236,7 +202,6 @@ namespace cortex
             other.m_size = size_type();
         }
 
-
         /// @brief Assign Copy Constructor
         ///
         /// @details Iterates from first to last and copys the
@@ -244,37 +209,27 @@ namespace cortex
         /// begin() iterator, thus copy is done row-wise.
         ///
         /// @tparam _It concept: [std::input_iterator]
-        /// @param first type: 
-        template<std::input_iterator _It>
-        constexpr box(_It first, _It last
-                     , size_type rows, size_type cols
-                     , [[maybe_unused]] const allocator_type& alloc = allocator_type())
-        : m_rows(rows)
-        , m_columns(cols)
-        , m_allocator(alloc)
-        , m_start(_M_allocate(_M_size(m_rows, m_columns)))
-        , m_finish(m_start + _M_size(m_rows, m_columns))
-        { std::ranges::uninitialized_copy(first, last, begin(), end()); }
-
+        /// @param first type:
+        template <std::input_iterator _It>
+        constexpr box(_It first, _It last, size_type rows, size_type cols, [[maybe_unused]] const allocator_type &alloc = allocator_type())
+            : m_rows(rows), m_columns(cols), m_allocator(alloc), m_start(_M_allocate(_M_size(m_rows, m_columns))), m_finish(m_start + _M_size(m_rows, m_columns))
+        {
+            std::ranges::uninitialized_copy(first, last, begin(), end());
+        }
 
         /// @brief Initialiser List Constructor
         ///
-        /// @details Uses std::initializer_list to create a box 
-        /// from an initializer list of initializer lists. Elements 
+        /// @details Uses std::initializer_list to create a box
+        /// from an initializer list of initializer lists. Elements
         /// ownership is moved to the box's memory.
         ///
         /// @param list type: [std::initializer_list<std::initializer_list<value_type>>] | qualifiers: [const], [ref]
-        constexpr box(std::initializer_list<std::initializer_list<value_type>> list
-                        , const allocator_type& alloc = allocator_type())
-        : m_rows(list.size())
-        , m_columns(list.begin()->size())
-        , m_allocator(alloc)
-        , m_start(_M_allocate(_M_size(m_rows, m_columns)))
-        , m_finish(m_start + _M_size(m_rows, m_columns))
+        constexpr box(std::initializer_list<std::initializer_list<value_type>> list, const allocator_type &alloc = allocator_type())
+            : m_rows(list.size()), m_columns(list.begin()->size()), m_allocator(alloc), m_start(_M_allocate(_M_size(m_rows, m_columns))), m_finish(m_start + _M_size(m_rows, m_columns))
         {
             using init_iter = typename decltype(list)::iterator;
-            auto offset { 0uL };
-            for (init_iter row { list.begin() }; row not_eq list.end(); ++row)
+            auto offset{0uL};
+            for (init_iter row{list.begin()}; row not_eq list.end(); ++row)
             {
                 if (row->size() not_eq this->m_columns)
                     throw std::invalid_argument("Columns must be all the same size");
@@ -283,16 +238,15 @@ namespace cortex
             }
         }
 
-
         /// @brief Copy Assignment
-        /// 
+        ///
         /// @details Copies the contents of another box into
         /// this box and returns///this. If self assignment occurs
         /// then///this is returned immediately.
-        /// 
+        ///
         /// @param other type: [box] | qualifiers: [const], [ref]
-        /// @return constexpr box& 
-        constexpr box& operator=(const box& other)
+        /// @return constexpr box&
+        constexpr box &operator=(const box &other)
         {
             if (*this not_eq other)
             {
@@ -306,17 +260,16 @@ namespace cortex
             return *this;
         }
 
-
         /// @brief Move Assignment
-        /// 
+        ///
         /// @details Moves the ownership of other's resources to
         /// this box and leaves the other box in a default
-        /// constructed state. Returns///this. If self assignment 
+        /// constructed state. Returns///this. If self assignment
         /// occurs then///this is returned immediately.
-        /// 
+        ///
         /// @param other type: [box] | qualifiers: [move]
         /// @return constexpr box&
-        constexpr box& operator=(box&& other) noexcept
+        constexpr box &operator=(box &&other) noexcept
         {
             if (*this not_eq other)
             {
@@ -335,17 +288,16 @@ namespace cortex
             return *this;
         }
 
-
         /// @brief Initialiser List Assignment
         ///
-        /// @details Uses std::initializer_list to create a box 
-        /// from an initializer list of initializer lists. Elements 
+        /// @details Uses std::initializer_list to create a box
+        /// from an initializer list of initializer lists. Elements
         /// ownership is moved to the box's memory.
         ///
         /// @param list type: [std::initializer_list<std::initializer_list<value_type>>] | qualifiers: [const], [ref]
         /// @return constexpr box&
-        constexpr box& operator= (std::initializer_list<std::initializer_list<value_type>> list)
-        {   
+        constexpr box &operator=(std::initializer_list<std::initializer_list<value_type>> list)
+        {
             m_allocator = allocator_type();
             m_rows = list.size();
             m_columns = list.begin()->size();
@@ -353,8 +305,8 @@ namespace cortex
             m_finish = m_start + _M_size(m_rows, m_columns);
 
             using init_iter = typename decltype(list)::iterator;
-            auto offset { 0uL };
-            for (init_iter row { list.begin() }; row not_eq list.end(); ++row)
+            auto offset{0uL};
+            for (init_iter row{list.begin()}; row not_eq list.end(); ++row)
             {
                 if (row->size() not_eq this->m_columns)
                     throw std::invalid_argument("Columns must be all the same size");
@@ -365,16 +317,15 @@ namespace cortex
             return *this;
         }
 
-        
         /// @brief Destructor
-        /// 
+        ///
         /// @details Releases the resources of this box
-        /// and leaves the box in an uninitialized state. 
-    #if __cplusplus >= 202202L
+        /// and leaves the box in an uninitialized state.
+#if __cplusplus >= 202202L
         constexpr ~box()
-    #else
+#else
         ~box()
-    #endif
+#endif
         {
             if (m_start)
             {
@@ -389,31 +340,30 @@ namespace cortex
             m_allocator = allocator_type();
         }
 
-
         /// @brief Resizes the box to dimensions new_rows x new_columns.
         ///
-        /// @details Resizes the box to dimensions new_rows x new_columns, 
+        /// @details Resizes the box to dimensions new_rows x new_columns,
         /// the resize will result in a new memory block being allocated
-        /// if the new dimensions are larger or smaller than the current dimensions. 
-        /// Reallocation or destruction of elements causes iterators and references 
+        /// if the new dimensions are larger or smaller than the current dimensions.
+        /// Reallocation or destruction of elements causes iterators and references
         /// to be invalidated. If new dimensions don't change the overall size, only
-        /// the view over the data (ie. the dimension sizes) are changed, elements 
-        /// of the box remain unchanged, however, this is unchecked. For a checked  
-        /// change that can only changes the dimension sizes, use box::reshape. 
-        /// 
+        /// the view over the data (ie. the dimension sizes) are changed, elements
+        /// of the box remain unchanged, however, this is unchecked. For a checked
+        /// change that can only changes the dimension sizes, use box::reshape.
+        ///
         /// @param new_rows type: [size_type]
         /// @param new_columns type: [size_type]
         constexpr void resize(size_type new_rows, size_type new_columns)
         {
-            auto old_size { _M_size(m_rows, m_columns) };
-            
-            if (auto new_size { _M_size(new_rows, new_columns) }; new_size > alloc_traits::max_size(m_allocator))
+            auto old_size{_M_size(m_rows, m_columns)};
+
+            if (auto new_size{_M_size(new_rows, new_columns)}; new_size > alloc_traits::max_size(m_allocator))
                 throw std::length_error("Matrix resize too large");
             else
             {
-                auto new_start { _M_allocate(new_size) };
-                auto old_finish_pos_in_new { new_start + old_size };
-                auto new_finish { new_start + new_size };
+                auto new_start{_M_allocate(new_size)};
+                auto old_finish_pos_in_new{new_start + old_size};
+                auto new_finish{new_start + new_size};
 
                 if (old_size < new_size)
                 {
@@ -423,7 +373,7 @@ namespace cortex
                         std::ranges::uninitialized_default_construct(old_finish_pos_in_new, new_finish);
                     }
                     else
-                        std::ranges::uninitialized_default_construct(new_start, new_finish); 
+                        std::ranges::uninitialized_default_construct(new_start, new_finish);
                 }
                 else if (old_size > new_size)
                 {
@@ -432,7 +382,7 @@ namespace cortex
                     else
                         std::ranges::uninitialized_default_construct(old_finish_pos_in_new, new_finish);
                 }
-                
+
                 std::ranges::destroy(*this);
                 _M_deallocate(m_start, old_size);
 
@@ -444,33 +394,32 @@ namespace cortex
             m_columns = new_columns;
         }
 
-
         /// @brief Resizes the box to dimensions new_rows x new_columns with default value
         ///
-        /// @details Resizes the box to dimensions new_rows x new_columns, 
+        /// @details Resizes the box to dimensions new_rows x new_columns,
         /// the resize will result in a new memory block being allocated
-        /// if the new dimensions are larger or smaller than the current dimensions. 
-        /// Reallocation or destruction of elements causes iterators and references 
-        /// to be invalidated. The new box is initialised with value. If new dimensions 
-        /// don't change the overall size, only the view over the data (ie. the dimension 
-        /// sizes) are changed, elements of the box remain unchanged, however, this is 
-        /// unchecked. For a checked change that can only changes the dimension sizes, use 
-        /// box::reshape. 
-        /// 
+        /// if the new dimensions are larger or smaller than the current dimensions.
+        /// Reallocation or destruction of elements causes iterators and references
+        /// to be invalidated. The new box is initialised with value. If new dimensions
+        /// don't change the overall size, only the view over the data (ie. the dimension
+        /// sizes) are changed, elements of the box remain unchanged, however, this is
+        /// unchecked. For a checked change that can only changes the dimension sizes, use
+        /// box::reshape.
+        ///
         /// @param new_rows type: [size_type]
         /// @param new_columns type: [size_type]
         /// @param value type: [value_type] | qualifiers: [const], [ref]
-        constexpr void resize(size_type new_rows, size_type new_columns, const value_type& value)
+        constexpr void resize(size_type new_rows, size_type new_columns, const value_type &value)
         {
-            auto old_size { _M_size(m_rows, m_columns) };
+            auto old_size{_M_size(m_rows, m_columns)};
 
-            if (auto new_size { _M_size(new_rows, new_columns) }; new_size > alloc_traits::max_size(m_allocator))
+            if (auto new_size{_M_size(new_rows, new_columns)}; new_size > alloc_traits::max_size(m_allocator))
                 throw std::length_error("Matrix resize too large");
             else
             {
-                auto new_start { _M_allocate(new_size) };
-                auto old_finish_pos_in_new { new_start + old_size };
-                auto new_finish { new_start + new_size };
+                auto new_start{_M_allocate(new_size)};
+                auto old_finish_pos_in_new{new_start + old_size};
+                auto new_finish{new_start + new_size};
 
                 if (old_size < new_size)
                 {
@@ -480,7 +429,7 @@ namespace cortex
                         std::ranges::uninitialized_fill(old_finish_pos_in_new, new_finish, value);
                     }
                     else
-                        std::ranges::uninitialized_fill(new_start, new_finish, value); 
+                        std::ranges::uninitialized_fill(new_start, new_finish, value);
                 }
                 else if (old_size > new_size)
                 {
@@ -489,7 +438,7 @@ namespace cortex
                     else
                         std::ranges::uninitialized_fill(old_finish_pos_in_new, new_finish, value);
                 }
-                
+
                 std::ranges::destroy(*this);
                 _M_deallocate(m_start, old_size);
 
@@ -505,10 +454,10 @@ namespace cortex
         ///
         /// @details Erases the value of the box at position
         /// and resets it to value_type().
-        /// 
+        ///
         /// @param position type: [const_iterator]
-        /// @return constexpr iterator - attr: [[maybe_unused]] 
-        /// :>> Returns the iterator to the erased position 
+        /// @return constexpr iterator - attr: [[maybe_unused]]
+        /// :>> Returns the iterator to the erased position
         [[maybe_unused]] constexpr iterator erase(const_iterator position)
         {
             std::ranges::destroy_at(std::addressof(*position));
@@ -518,14 +467,14 @@ namespace cortex
         }
 
         /// @brief Erases value between first and last
-        /// 
+        ///
         /// @details Elements between first and last and then
-        /// resets memory to value_type() 
-        /// 
+        /// resets memory to value_type()
+        ///
         /// @param first type: [const_iterator]
         /// @param last type: [const_iterator]
-        /// @return constexpr iterator - attr: [[maybe_unused]] 
-        /// :>> Returns the iterator indicated the start of the erase 
+        /// @return constexpr iterator - attr: [[maybe_unused]]
+        /// :>> Returns the iterator indicated the start of the erase
         [[maybe_unused]] constexpr iterator erase(const_iterator first, const_iterator last)
         {
             std::ranges::destroy(first, last);
@@ -534,12 +483,11 @@ namespace cortex
             return first;
         }
 
-
         /// @brief Clears the box elements
-        /// 
+        ///
         /// @details The elements of the box are destroyed and
         /// the memory is deallocated entirely. The box is however,
-        /// left in a state where it could be re-initialised or 
+        /// left in a state where it could be re-initialised or
         /// destructed which is up to user descretionbx. box::resize
         /// has to be used to allocate storage for the new elements.
         constexpr void clear()
@@ -555,18 +503,17 @@ namespace cortex
             }
         }
 
-
         /// @brief Reshape current box elements to new dimensions
         ///
-        /// @details Reshapes the current box's dimensisons while 
-        /// guranteeing that now reallocation occurs. Elements are 
+        /// @details Reshapes the current box's dimensisons while
+        /// guranteeing that now reallocation occurs. Elements are
         /// preserved.
-        /// 
+        ///
         /// @param new_rows type: [size_type]
         /// @param new_columns type: [size_type]
         constexpr void reshape(size_type new_rows, size_type new_columns)
         {
-            auto new_size { _M_size(new_rows, new_columns) };
+            auto new_size{_M_size(new_rows, new_columns)};
 
             if (new_size not_eq _M_size(m_rows, m_columns))
                 throw std::length_error("Cannot reshape box that has different total size");
@@ -574,215 +521,228 @@ namespace cortex
                 resize(new_rows, new_columns);
         }
 
-
         /// @brief Swaps two matrices of the same type.
-        /// 
-        /// @details Swaps the contents of two matrices of 
+        ///
+        /// @details Swaps the contents of two matrices of
         /// which they are the same type. The swap is performed
-        /// by moving ownership of the matrices resources. 
-        /// 
+        /// by moving ownership of the matrices resources.
+        ///
         /// @param other type: [box] | qualifiers: [ref]
-        void swap(box& other) noexcept
+        void swap(box &other) noexcept
         {
             box tmp = std::move(other);
             other = std::move(*this);
-           *this = std::move(tmp);
+            *this = std::move(tmp);
         }
 
-
         /// @brief Get Allocator
-        /// 
+        ///
         /// @details Returns the allocator used by the box.
-        /// 
-        /// @return constexpr allocator_type 
+        ///
+        /// @return constexpr allocator_type
         constexpr allocator_type get_allocator() const noexcept
-        { return m_allocator; }
-        
+        {
+            return m_allocator;
+        }
 
         /// @brief Returns the overall size of the box.
-        /// 
+        ///
         /// @return constexpr size_type
         constexpr size_type size() const noexcept
-        { return empty() ? size_type(0) : _M_size(m_rows, m_columns); }
-
+        {
+            return empty() ? size_type(0) : _M_size(m_rows, m_columns);
+        }
 
         /// @brief Returns the number of the rows of the box.
-        /// 
+        ///
         /// @return constexpr size_type
         constexpr size_type rows() const noexcept
-        { return m_rows; } 
-
+        {
+            return m_rows;
+        }
 
         /// @brief Returns the the number of columns in the box.
-        /// 
+        ///
         /// @return constexpr size_type
         constexpr size_type columns() const noexcept
-        { return m_columns; }
-
+        {
+            return m_columns;
+        }
 
         /// @brief Returns the maximum number of elements that
         /// can be stored in the box.
-        /// 
-        /// @return constexpr size_type 
+        ///
+        /// @return constexpr size_type
         constexpr size_type max_size() const noexcept
-        { return alloc_traits::max_size(m_allocator); }
+        {
+            return alloc_traits::max_size(m_allocator);
+        }
 
-
-        /// @brief Returns a structured binding of the box's 
+        /// @brief Returns a structured binding of the box's
         /// dimensions.
-        /// 
+        ///
         /// @return constexpr auto : (structured binding)
         constexpr auto dimensions() const noexcept
-        { return std::tie(m_rows, m_columns); }
-
+        {
+            return std::tie(m_rows, m_columns);
+        }
 
         /// @brief Checks whether the box is square.
-        /// 
+        ///
         /// @details If the number of rows and columns are equal,
         /// the box is square.
-        /// 
-        /// @return true 
+        ///
+        /// @return true
         /// @return false
         constexpr bool is_square() const noexcept
-        { return m_rows == m_columns; }
-
+        {
+            return m_rows == m_columns;
+        }
 
         /// @brief Checks if the box is empty.
-        /// 
-        /// @return true 
+        ///
+        /// @return true
         /// @return false
         constexpr bool empty() const noexcept
-        { return m_start == m_finish; }
-
+        {
+            return m_start == m_finish;
+        }
 
         /// @brief Returns the underlying data pointer.
-        /// 
-        /// @return pointer 
+        ///
+        /// @return pointer
         pointer data() noexcept
-        { return _M_data_ptr(m_start); }
-
+        {
+            return _M_data_ptr(m_start);
+        }
 
         /// @brief Returns the underlying data pointer.
-        /// 
+        ///
         /// @return const_pointer
         const_pointer data() const noexcept
-        { return _M_data_ptr(m_start); }
-
+        {
+            return _M_data_ptr(m_start);
+        }
 
         /// @brief Subscript Operator.
-        /// 
-        /// @details Returns a reference to the element that 
-        /// is at the position indicated by the pointer 
+        ///
+        /// @details Returns a reference to the element that
+        /// is at the position indicated by the pointer
         /// m_data + step. Offers linear access to the box's
         /// elements.
-        /// 
+        ///
         /// @param step type: [size_type]
         /// @return constexpr reference
-        constexpr reference operator[](size_type step) 
-        { return *(m_start + step); }
-
+        constexpr reference operator[](size_type step)
+        {
+            return *(m_start + step);
+        }
 
         /// @brief Two Dimensional Element Access (Point Access).
-        /// 
+        ///
         /// @details Returns a reference to the element that
-        /// is at the point position (column, row) of the 
-        /// box. 
-        /// 
+        /// is at the point position (column, row) of the
+        /// box.
+        ///
         /// @exception std::out_of_range
-        /// 
+        ///
         /// @param column type: [size_type]
         /// @param row type: [size_type]
         /// @return constexpr reference
         constexpr reference at(size_type row, size_type column)
-        { 
+        {
             _M_range_check(row, column);
             return *(m_start + (m_columns * row) + column);
         }
 
-
         /// @brief Two Dimensional Element Access (Point Access).
-        /// 
+        ///
         /// @details Returns a reference to the element that
-        /// is at the point position (column, row) of the 
-        /// box.  
-        /// 
+        /// is at the point position (column, row) of the
+        /// box.
+        ///
         /// @exception std::out_of_range
-        /// 
+        ///
         /// @param column type: [size_type]
         /// @param row type: [size_type]
-        /// @return constexpr const_reference 
+        /// @return constexpr const_reference
         constexpr const_reference at(size_type row, size_type column) const
-        { 
+        {
             _M_range_check(row, column);
-            return *(m_start + (m_columns * row) + column); 
+            return *(m_start + (m_columns * row) + column);
         }
 
-
         /// @brief Point Access Operator.
-        /// 
+        ///
         /// @details Provides point access to box's elements.
-        /// Overloads the invokation operator. Utilises the at() method. 
-        /// 
+        /// Overloads the invokation operator. Utilises the at() method.
+        ///
         /// @exception std::out_of_range
-        /// 
+        ///
         /// @param column type: [size_type]
         /// @param row type: [size_type]
         /// @return constexpr reference
-        constexpr reference operator() (size_type row, size_type column) 
-        { return this->at(row, column); }
-
+        constexpr reference operator()(size_type row, size_type column)
+        {
+            return this->at(row, column);
+        }
 
         /// @brief Point Access Operator.
-        /// 
+        ///
         /// @details Provides point access to box's elements.
-        /// Overloads the invokation operator. Utilises the at() method. 
-        /// 
-        /// @exception std::out_of_range 
-        /// 
+        /// Overloads the invokation operator. Utilises the at() method.
+        ///
+        /// @exception std::out_of_range
+        ///
         /// @param column type: [size_type]
         /// @param row type: [size_type]
-        /// @return constexpr const_reference 
-        constexpr const_reference operator() (size_type row, size_type column) const
-        { return this->at(row, column); }
+        /// @return constexpr const_reference
+        constexpr const_reference operator()(size_type row, size_type column) const
+        {
+            return this->at(row, column);
+        }
 
-
-        /// @brief Returns a reference to the front element 
-        /// of the box. 
-        /// 
-        /// @return constexpr reference 
-        constexpr reference front() noexcept
-        { return *(this->begin()); }
-
-
-        /// @brief Returns a reference to the front element 
+        /// @brief Returns a reference to the front element
         /// of the box.
-        /// 
+        ///
+        /// @return constexpr reference
+        constexpr reference front() noexcept
+        {
+            return *(this->begin());
+        }
+
+        /// @brief Returns a reference to the front element
+        /// of the box.
+        ///
         /// @return constexpr const_reference
         constexpr const_reference front() const noexcept
-        { return *(this->begin()); }
+        {
+            return *(this->begin());
+        }
 
-
-        /// @brief Returns a reference to the back element 
+        /// @brief Returns a reference to the back element
         /// of the box.
-        /// 
+        ///
         /// @return constexpr reference
         constexpr reference back() noexcept
-        { return *(this->end() - 1); }
+        {
+            return *(this->end() - 1);
+        }
 
-
-        /// @brief Returns a reference to the back element 
+        /// @brief Returns a reference to the back element
         /// of the box.
-        /// 
+        ///
         /// @return constexpr const_reference
         constexpr const_reference back() const noexcept
-        { return *(this->end() - 1); }
-
+        {
+            return *(this->end() - 1);
+        }
 
         /// @brief Flattens the box into a std::vector.
-        /// 
+        ///
         /// @details Creates a vector of the box's elements
         /// in row major order.
-        /// 
+        ///
         /// @return constexpr std::vector<value_type>
         constexpr std::vector<value_type> flatten() const noexcept
         {
@@ -791,218 +751,221 @@ namespace cortex
             return vec;
         }
 
-
-        /// @brief Iterator to the beginning of the box. 
-        /// 
+        /// @brief Iterator to the beginning of the box.
+        ///
         /// @return constexpr iterator
         constexpr iterator begin() noexcept
-        { return iterator(m_start); }
-
+        {
+            return iterator(m_start);
+        }
 
         /// @brief Constant iterator to the beginning of the box.
-        /// 
+        ///
         /// @return constexpr const_iterator
         constexpr const_iterator begin() const noexcept
-        { return const_iterator(m_start); }
-
+        {
+            return const_iterator(m_start);
+        }
 
         /// @brief Constant iterator to the beginning of the box.
-        /// 
+        ///
         /// @return constexpr const_iterator
         constexpr const_iterator cbegin() const noexcept
-        { return const_iterator(m_start); }
-
+        {
+            return const_iterator(m_start);
+        }
 
         /// @brief Reverse iterator to the end of the box.
-        /// 
+        ///
         /// @return constexpr reverse_iterator
         constexpr reverse_iterator rbegin() noexcept
-        { return reverse_iterator(end()); }
-
+        {
+            return reverse_iterator(end());
+        }
 
         /// @brief Constant reverse iterator to the end of the box.
-        /// 
-        /// @return constexpr const_reverse_iterator 
+        ///
+        /// @return constexpr const_reverse_iterator
         constexpr const_reverse_iterator rbegin() const noexcept
-        { return const_reverse_iterator(end()); }
-
+        {
+            return const_reverse_iterator(end());
+        }
 
         /// @brief Constant reverse iterator to the end of the box.
-        /// 
+        ///
         /// @return constexpr const_reverse_iterator
         constexpr const_reverse_iterator crbegin() const noexcept
-        { return const_reverse_iterator(end()); }
-
+        {
+            return const_reverse_iterator(end());
+        }
 
         /// @brief Iterator to the end of the box.
-        /// 
-        /// @return constexpr iterator 
+        ///
+        /// @return constexpr iterator
         constexpr iterator end() noexcept
-        { return iterator(m_finish); }
+        {
+            return iterator(m_finish);
+        }
 
-        
         /// @brief Constant iterator to the end of the box.
-        /// 
+        ///
         /// @return constexpr const_iterator
         constexpr const_iterator end() const noexcept
-        { return const_iterator(m_finish); }
-
+        {
+            return const_iterator(m_finish);
+        }
 
         /// @brief Constant iterator to the end of the box.
-        /// 
+        ///
         /// @return constexpr const_iterator
         constexpr const_iterator cend() const noexcept
-        { return const_iterator(m_finish); }
-
+        {
+            return const_iterator(m_finish);
+        }
 
         /// @brief Reverse iterator to the beginning of the box.
-        /// 
-        /// @return constexpr reverse_iterator 
+        ///
+        /// @return constexpr reverse_iterator
         constexpr reverse_iterator rend() noexcept
-        { return reverse_iterator(begin()); }
-
+        {
+            return reverse_iterator(begin());
+        }
 
         /// @brief Constant reverse iterator to the beginning of the box.
-        /// 
-        /// @return constexpr const_reverse_iterator 
+        ///
+        /// @return constexpr const_reverse_iterator
         constexpr const_reverse_iterator rend() const noexcept
-        { return const_reverse_iterator(begin()); }
-
+        {
+            return const_reverse_iterator(begin());
+        }
 
         /// @brief Constant reverse iterator to the beginning of the box.
-        /// 
+        ///
         /// @return constexpr const_reverse_iterator
         constexpr const_reverse_iterator crend() const noexcept
-        { return const_reverse_iterator(begin()); }
-
+        {
+            return const_reverse_iterator(begin());
+        }
 
         /// @brief Row Begin Iterator
         ///
         /// @details Returns an iterator to the beginning of the row.
-        /// 
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr row_iterator 
-        constexpr row_iterator row_begin(size_type row = 0uL) 
-        { 
+        /// @return constexpr row_iterator
+        constexpr row_iterator row_begin(size_type row = 0uL)
+        {
             _M_range_check(row, 0uL);
-            return row_iterator(begin() + _M_index(row, 0uL), row, 0uL, rows(), columns()); 
+            return row_iterator(begin() + _M_index(row, 0uL), row, 0uL, rows(), columns());
         }
-
 
         /// @brief Row Begin Iterator (const)
         ///
         /// @details Returns an iterator to the beginning of the row.
-        /// 
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr const_row_iterator 
+        /// @return constexpr const_row_iterator
         constexpr const_row_iterator row_begin(size_type row = 0uL) const
-        { 
+        {
             _M_range_check(row, 0uL);
-            return const_row_iterator(begin() + _M_index(row, 0uL), row, 0uL, rows(), columns()); 
+            return const_row_iterator(begin() + _M_index(row, 0uL), row, 0uL, rows(), columns());
         }
-
 
         /// @brief Constant Row Begin Iterator
         ///
-        /// @details Returns a constant iterator to the beginning 
-        /// of the row. 
-        /// 
+        /// @details Returns a constant iterator to the beginning
+        /// of the row.
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr const_row_iterator 
-        constexpr const_row_iterator row_cbegin(size_type row = 0uL) const 
+        /// @return constexpr const_row_iterator
+        constexpr const_row_iterator row_cbegin(size_type row = 0uL) const
         {
             _M_range_check(row, 0uL);
-            return const_row_iterator(cbegin() + _M_index(row, 0uL), row, 0uL, rows(), columns()); 
+            return const_row_iterator(cbegin() + _M_index(row, 0uL), row, 0uL, rows(), columns());
         }
 
-
-        /// @brief Reverse Row Begin Iterator 
+        /// @brief Reverse Row Begin Iterator
         ///
         /// @details Returns a reverse iterator to the beginning of the
-        /// reversed row. 
-        /// 
+        /// reversed row.
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr reverse_row_iterator 
+        /// @return constexpr reverse_row_iterator
         constexpr reverse_row_iterator row_rbegin(size_type row = 0uL)
         {
             _M_range_check(row, 0uL);
             return reverse_row_iterator(row_end(row));
         }
 
-
         /// @brief Reverse Row Begin Iterator (const)
         ///
         /// @details Returns a constant reverse iterator to the
-        /// beginning of the reversed row. 
-        /// 
+        /// beginning of the reversed row.
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr const_reverse_row_iterator 
+        /// @return constexpr const_reverse_row_iterator
         constexpr const_reverse_row_iterator row_rbegin(size_type row = 0uL) const
         {
             _M_range_check(row, 0uL);
             return const_reverse_row_iterator(row_end(row));
         }
 
-
         /// @brief Constant Reverse Row Begin Iterator
         ///
         /// @details Returns a constant reverse iterator to the
-        /// beginning of the reversed row.  
-        /// 
-        /// @param row 
-        /// @return constexpr const_reverse_row_iterator 
+        /// beginning of the reversed row.
+        ///
+        /// @param row
+        /// @return constexpr const_reverse_row_iterator
         constexpr const_reverse_row_iterator row_crbegin(size_type row = 0uL) const
         {
             _M_range_check(row, 0uL);
             return const_reverse_row_iterator(row_end(row));
         }
 
-
         /// @brief Row End Iterator
         ///
-        /// @details Returns an iterator to one past the end of the 
+        /// @details Returns an iterator to one past the end of the
         /// row, this happens to be the first element in the next row.
-        /// This is why the iterator column index is set to 0 and the 
-        /// row index is one plus the indicated positon. 
-        /// 
+        /// This is why the iterator column index is set to 0 and the
+        /// row index is one plus the indicated positon.
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr row_iterator 
+        /// @return constexpr row_iterator
         constexpr row_iterator row_end(size_type row = 0uL)
         {
             _M_range_check(row, 0uL);
             return row_iterator(begin() + _M_index(row + 1uL, 0uL), row + 1uL, 0uL, rows(), columns());
         }
 
-
         /// @brief Row End Iterator (const)
         ///
-        /// @details Returns an constant iterator to one past the 
-        /// end of the row, this happens to be the first element 
-        /// in the next row. This is why the iterator column index 
-        /// is set to 0 and the row index is one plus the indicated 
-        /// positon.  
-        /// 
+        /// @details Returns an constant iterator to one past the
+        /// end of the row, this happens to be the first element
+        /// in the next row. This is why the iterator column index
+        /// is set to 0 and the row index is one plus the indicated
+        /// positon.
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr const_row_iterator 
+        /// @return constexpr const_row_iterator
         constexpr const_row_iterator row_end(size_type row = 0uL) const
-        { 
+        {
             _M_range_check(row, 0uL);
             return const_row_iterator(begin() + _M_index(row + 1uL, 0uL), row + 1uL, 0uL, rows(), columns());
         }
 
-
         /// @brief Constant Row End Iterator
         ///
-        /// @details Returns an constant iterator to one past the 
-        /// end of the row, this happens to be the first element 
-        /// in the next row. This is why the iterator column index 
-        /// is set to 0 and the row index is one plus the indicated 
-        /// positon. 
-        /// 
+        /// @details Returns an constant iterator to one past the
+        /// end of the row, this happens to be the first element
+        /// in the next row. This is why the iterator column index
+        /// is set to 0 and the row index is one plus the indicated
+        /// positon.
+        ///
         /// @param row type: size_type | default: 0uL
-        /// @return constexpr const_row_iterator 
+        /// @return constexpr const_row_iterator
         constexpr const_row_iterator row_cend(size_type row = 0uL) const
-        { 
+        {
             _M_range_check(row, 0uL);
             return const_row_iterator(cbegin() + _M_index(row + 1uL, 0uL), row + 1uL, 0uL, rows(), columns());
         }
@@ -1010,58 +973,54 @@ namespace cortex
         /// @brief Reverse Row End Iterator
         ///
         /// @details Returns a reverse iterator to the end of the
-        /// reversed row. 
-        /// 
-        /// @param row 
-        /// @return constexpr reverse_row_iterator 
+        /// reversed row.
+        ///
+        /// @param row
+        /// @return constexpr reverse_row_iterator
         constexpr reverse_row_iterator row_rend(size_type row = 0uL)
         {
             _M_range_check(row, 0uL);
             return reverse_row_iterator(row_begin(row));
         }
 
-
         /// @brief Reverse Row End Iterator (const)
         ///
         /// @details Returns a constant reverse iterator to the
-        /// end of the reversed row. 
-        /// 
-        /// @param row 
-        /// @return constexpr const_reverse_row_iterator 
+        /// end of the reversed row.
+        ///
+        /// @param row
+        /// @return constexpr const_reverse_row_iterator
         constexpr const_reverse_row_iterator row_rend(size_type row = 0uL) const
         {
             _M_range_check(row, 0uL);
             return const_reverse_row_iterator(row_begin(row));
         }
 
-
         /// @brief Constant Reverse Row End Iterator
         ///
         /// @details Returns a constant reverse iterator to the
         /// end of the reversed row.
-        /// 
-        /// @param row 
-        /// @return constexpr const_reverse_row_iterator 
+        ///
+        /// @param row
+        /// @return constexpr const_reverse_row_iterator
         constexpr const_reverse_row_iterator row_crend(size_type row = 0uL) const
         {
             _M_range_check(row, 0uL);
             return const_reverse_row_iterator(row_begin(row));
         }
 
-
         /// @brief Column Begin Iterator
         ///
         /// @details Returns an iterator to the beginning of the
         /// column.
-        /// 
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr column_iterator 
+        /// @return constexpr column_iterator
         constexpr column_iterator column_begin(size_type column = 0uL)
         {
             _M_range_check(0uL, column);
             return column_iterator(begin() + _M_index(0uL, column), 0uL, column, rows(), columns());
         }
-
 
         /// @brief Column Begin Iterator (const)
         ///
@@ -1076,62 +1035,57 @@ namespace cortex
             return const_column_iterator(cbegin() + _M_index(0uL, column), 0uL, column, rows(), columns());
         }
 
-
         /// @brief Constant Column Begin Iterator
         ///
         /// @details Returns a constant iterator to the beginning of
-        /// the column. 
-        /// 
+        /// the column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_column_iterator 
+        /// @return constexpr const_column_iterator
         constexpr const_column_iterator column_cbegin(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_column_iterator(cbegin() + _M_index(0uL, column), 0uL, column, rows(), columns());
         }
 
-
         /// @brief Reverse Column Begin Iterator
         ///
         /// @details Returns a reverse iterator to the beginning of
-        /// the reversed column. 
-        /// 
+        /// the reversed column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr reverse_column_iterator 
+        /// @return constexpr reverse_column_iterator
         constexpr reverse_column_iterator column_rbegin(size_type column = 0uL)
         {
             _M_range_check(0uL, column);
             return reverse_column_iterator(column_end(column));
         }
 
-
         /// @brief Reverse Column Begin Iterator (const)
         ///
         /// @details Returns a constant reverse iterator to the
-        /// beginning of the reversed column. 
-        /// 
+        /// beginning of the reversed column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_reverse_column_iterator 
+        /// @return constexpr const_reverse_column_iterator
         constexpr const_reverse_column_iterator column_rbegin(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_reverse_column_iterator(column_cend(column));
         }
 
-
         /// @brief Constant Reverse Column Begin Iterator
         ///
         /// @details Returns a constant reverse iterator to the
-        /// beginning of the reversed column. 
-        /// 
+        /// beginning of the reversed column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_reverse_column_iterator 
+        /// @return constexpr const_reverse_column_iterator
         constexpr const_reverse_column_iterator column_crbegin(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_reverse_column_iterator(column_cend(column));
         }
-
 
         /// @brief Column End Iterator
         ///
@@ -1140,32 +1094,30 @@ namespace cortex
         /// next column. This is why the iterator row index is set
         /// to 0 and the column index is one plus the indicated
         /// position.
-        /// 
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr column_iterator 
+        /// @return constexpr column_iterator
         constexpr column_iterator column_end(size_type column = 0uL)
         {
             _M_range_check(0uL, column);
             return column_iterator(begin() + _M_index(0uL, column + 1uL), 0uL, column + 1uL, rows(), columns());
         }
 
-
-        /// @brief Column End Iterator (const) 
+        /// @brief Column End Iterator (const)
         ///
         /// @details Returns a constant iterator to one past the end
         /// of the column, this happens to be the first element in the
         /// next column. This is why the iterator row index is set
         /// to 0 and the column index is one plus the indicated
         /// position.
-        /// 
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_column_iterator 
+        /// @return constexpr const_column_iterator
         constexpr const_column_iterator column_end(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_column_iterator(cbegin() + _M_index(0uL, column + 1uL), 0uL, column + 1uL, rows(), columns());
         }
-
 
         /// @brief Constant Column End Iterator
         ///
@@ -1173,79 +1125,75 @@ namespace cortex
         /// of the column, this happens to be the first element in the
         /// next column. This is why the iterator row index is set
         /// to 0 and the column index is one plus the indicated
-        /// position. 
-        /// 
+        /// position.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_column_iterator 
+        /// @return constexpr const_column_iterator
         constexpr const_column_iterator column_cend(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_column_iterator(cbegin() + _M_index(0uL, column + 1uL), 0uL, column + 1uL, rows(), columns());
         }
 
-
         /// @brief Reverse Column End Iterator
         ///
         /// @details Returns a reverse iterator the end of the
-        /// reversed column. 
-        /// 
+        /// reversed column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr reverse_column_iterator 
+        /// @return constexpr reverse_column_iterator
         constexpr reverse_column_iterator column_rend(size_type column = 0uL)
         {
             _M_range_check(0uL, column);
             return reverse_column_iterator(column_begin(column));
         }
 
-
         /// @brief Reverse Column End Iterator (const)
         ///
         /// @details Returns a constant reverse iterator the end of
-        /// the reversed column. 
-        /// 
+        /// the reversed column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_reverse_column_iterator 
+        /// @return constexpr const_reverse_column_iterator
         constexpr const_reverse_column_iterator column_rend(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_reverse_column_iterator(column_cbegin(column));
         }
 
-        
         /// @brief Constant Reverse Column End Iterator
         ///
         /// @details Returns a constant reverse iterator the end of
-        /// the reversed column. 
-        /// 
+        /// the reversed column.
+        ///
         /// @param column type: size_type | default: 0uL
-        /// @return constexpr const_reverse_column_iterator 
+        /// @return constexpr const_reverse_column_iterator
         constexpr const_reverse_column_iterator column_crend(size_type column = 0uL) const
         {
             _M_range_check(0uL, column);
             return const_reverse_column_iterator(column_cbegin(column));
         }
 
-
-        /// @brief Adds the elements of one box by another.
+        /// @brief Box Element-wise Addition
         ///
-        /// @details Performs an element-wise addition 
-        /// between matrices. Matrices are `Addable` iff the 
-        /// type of this box's elements satisfies the 
+        /// @details Performs an element-wise addition
+        /// between matrices. Matrices are `Addable` iff the
+        /// type of this box's elements satisfies the
         /// concept of `Addable` and satisfies the concept
-        /// `AddableWith` with type of the elemnts of the 
-        /// passed box. A new box is created and returned. 
+        /// `AddableWith` with type of the elemnts of the
+        /// passed box. A new box is created and returned.
         ///
-        /// @requires The type of this box's elements are `Addable` 
+        /// @requires The type of this box's elements are `Addable`
         /// @requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `AddableWith`.
-        /// 
-        /// @tparam _ElemT 
-        /// @param other type: box<_ElemT> | qualifiers: [const], [ref] 
-        /// @return constexpr auto : A box whose element's type 
-        /// is the sum of the two input matrices element types. 
-        template<Addable _ElemT>
-            requires AddableWith<value_type, _ElemT>
-        constexpr auto add(const box<_ElemT>& other)
+        ///
+        /// @tparam _ElemT
+        /// @param other type: box<_ElemT> | qualifiers: [const], [ref]
+        /// @return constexpr auto : A box whose element's type
+        /// is the sum of the two input matrices element types.
+        template <Addable _ElemT>
+        requires AddableWith<value_type, _ElemT>
+        constexpr auto add(const box<_ElemT> &other)
             -> box<decltype(std::declval<value_type>() + std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1258,28 +1206,27 @@ namespace cortex
             return result;
         }
 
-
-        /// @brief Substracts the elements of one box from another.
+        /// @brief Box Element-wise Subtraction
         ///
-        /// @details Performs an element-wise subtraction 
-        /// between matrices. Matrices are `Subtractable` 
-        /// iff the type of this box's elements satisfies 
-        /// the concept of `Subtractable` and satisfies the 
-        /// concept `SubtractableWith` with type of the elemnts 
-        /// of the passed box. A new box is created and 
-        /// returned. 
+        /// @details Performs an element-wise subtraction
+        /// between matrices. Matrices are `Subtractable`
+        /// iff the type of this box's elements satisfies
+        /// the concept of `Subtractable` and satisfies the
+        /// concept `SubtractableWith` with type of the elemnts
+        /// of the passed box. A new box is created and
+        /// returned.
         ///
-        /// @requires The type of this box's elements are `Subtractable` 
+        /// @requires The type of this box's elements are `Subtractable`
         /// @requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `SubtractableWith`.
-        /// 
-        /// @tparam _ElemT 
-        /// @param other type: box<_ElemT> | qualifiers: [const], [ref] 
-        /// @return constexpr auto : A box whose element type 
+        ///
+        /// @tparam _ElemT
+        /// @param other type: box<_ElemT> | qualifiers: [const], [ref]
+        /// @return constexpr auto : A box whose element type
         /// is the difference of the two input matrices element types.
-        template<Subtractable _ElemT>
-            requires SubtractableWith<value_type, _ElemT>
-        constexpr auto sub(const box<_ElemT>& other)
+        template <Subtractable _ElemT>
+        requires SubtractableWith<value_type, _ElemT>
+        constexpr auto sub(const box<_ElemT> &other)
             -> box<decltype(std::declval<value_type>() - std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1292,28 +1239,27 @@ namespace cortex
             return result;
         }
 
-
-        /// @brief Multiplies the elements of one box by another..
+        /// @brief Box Element-wise Multiplication
         ///
-        /// @details Performs an element-wise multiplication 
-        /// between matrices. Matrices are `Multiplicible` 
-        /// iff the type of this box's elements satisfies 
-        /// the concept of `Multiplicable` and satisfies the 
-        /// concept `MultiplicableWith` with type of the elemnts 
-        /// of the passed box. A new box is created and 
-        /// returned. 
+        /// @details Performs an element-wise multiplication
+        /// between matrices. Matrices are `Multiplicible`
+        /// iff the type of this box's elements satisfies
+        /// the concept of `Multiplicable` and satisfies the
+        /// concept `MultiplicableWith` with type of the elemnts
+        /// of the passed box. A new box is created and
+        /// returned.
         ///
-        /// @requires The type of this box's elements are `Multiplicable` 
+        /// @requires The type of this box's elements are `Multiplicable`
         /// @requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `MultiplicableWith`.
-        /// 
-        /// @tparam _ElemT 
-        /// @param other type: box<_ElemT> | qualifiers: [const], [ref] 
-        /// @return constexpr auto : A box whose element type 
+        ///
+        /// @tparam _ElemT
+        /// @param other type: box<_ElemT> | qualifiers: [const], [ref]
+        /// @return constexpr auto : A box whose element type
         /// is the product of the two input matrices element types.
-        template<Multiplicable _ElemT>
-            requires MultiplicableWith<value_type, _ElemT>
-        constexpr auto mul(const box<_ElemT>& other)
+        template <Multiplicable _ElemT>
+        requires MultiplicableWith<value_type, _ElemT>
+        constexpr auto mul(const box<_ElemT> &other)
             -> box<decltype(std::declval<value_type>() * std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1326,23 +1272,22 @@ namespace cortex
             return result;
         }
 
-
-        /// @brief Scalar Matrix Multiplicationbx.
+        /// @brief Scalar Multiplication.
         ///
         /// @details Performs an element-wise multiplication of the box
-        /// by a 'scalar' value. 
+        /// by a 'scalar' value.
         ///
         /// @requires The type of this box's elements are `MultiplicableWith`
-        /// the type denoted _ScalarT. 
+        /// the type denoted _ScalarT.
         /// @requires The type denoted _ScalarT be `Multiplicable`.
         ///
-        /// 
-        /// @tparam _ScalarT 
+        ///
+        /// @tparam _ScalarT
         /// @param scalar type: _ScalarT | qualifiers: [const], [ref]
-        /// @return box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())> 
-        template<Multiplicable _ScalarT>
-            requires MultiplicableWith<value_type, _ScalarT>
-        constexpr auto mul(const _ScalarT& scalar)
+        /// @return box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
+        template <Multiplicable _ScalarT>
+        requires MultiplicableWith<value_type, _ScalarT>
+        constexpr auto mul(const _ScalarT &scalar)
             -> box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1350,37 +1295,37 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem * scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto &elem)
+                                   { return elem * scalar; });
 
             return result;
         }
 
-
-        /// @brief Divides the elements of one box by another.
+        /// @brief Box Element-wise Division
         ///
-        /// @details Performs an element-wise division 
-        /// between matrices. Matrices are `Divisible` 
-        /// iff the type of this box's elements satisfies 
-        /// the concept of `Divisible` and satisfies the 
-        /// concept `MultiplicibleWith` with type of the elemnts 
-        /// of the passed box. A new box is created and 
-        /// returned. 
+        /// @details Performs an element-wise division
+        /// between matrices. Matrices are `Divisible`
+        /// iff the type of this box's elements satisfies
+        /// the concept of `Divisible` and satisfies the
+        /// concept `MultiplicibleWith` with type of the elemnts
+        /// of the passed box. A new box is created and
+        /// returned.
         ///
-        /// @requires The type of this box's elements are `Divisible` 
+        /// @requires The type of this box's elements are `Divisible`
         /// @requires The type of this box's elements and the type
         /// of the passed box's element types satisfy `DivisibleWith`.
         ///
-        /// @note When dividing two matrices, if both matrices elements 
+        /// @note When dividing two matrices, if both matrices elements
         /// are integrals, the division is performed as integer divisionbx.
         /// due to C++ rounding rules.
-        /// 
-        /// @tparam _ElemT 
-        /// @param other type: box<_ElemT> | qualifiers: [const], [ref] 
-        /// @return constexpr auto : A box whose element type 
+        ///
+        /// @tparam _ElemT
+        /// @param other type: box<_ElemT> | qualifiers: [const], [ref]
+        /// @return constexpr auto : A box whose element type
         /// is the quotient of the two input matrices element types.
-        template<Divisible _ElemT>
-            requires DivisibleWith<value_type, _ElemT>
-        constexpr auto div(const box<_ElemT>& other)
+        template <Divisible _ElemT>
+        requires DivisibleWith<value_type, _ElemT>
+        constexpr auto div(const box<_ElemT> &other)
             -> box<decltype(std::declval<value_type>() / std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1393,26 +1338,25 @@ namespace cortex
             return result;
         }
 
-
-        /// @brief Scalar Matrix Division
+        /// @brief Scalar Division
         ///
         /// @details Performs an element-wise division of the box
-        /// by a 'scalar' value. 
+        /// by a 'scalar' value.
         ///
         /// @requires The type of this box's elements are `DivisibleWith`
-        /// the type denoted _ScalarT. 
+        /// the type denoted _ScalarT.
         /// @requires The type denoted _ScalarT be `Divisible`.
         ///
-        /// @note When dividing two matrices, if both matrices elements 
+        /// @note When dividing two matrices, if both matrices elements
         /// are integrals, the division is performed as integer divisionbx.
         /// due to C++ rounding rules.
-        /// 
-        /// @tparam _ScalarT 
+        ///
+        /// @tparam _ScalarT
         /// @param scalar type: _ScalarT | qualifiers: [const], [ref]
-        /// @return box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())> 
-        template<Divisible _ScalarT>
-            requires DivisibleWith<value_type, _ScalarT>
-        constexpr auto div(const _ScalarT& scalar)
+        /// @return box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
+        template <Divisible _ScalarT>
+        requires DivisibleWith<value_type, _ScalarT>
+        constexpr auto div(const _ScalarT &scalar)
             -> box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1422,26 +1366,26 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto& elem) { return elem / scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto &elem)
+                                   { return elem / scalar; });
 
             return result;
         }
 
-
-        /// @brief Box Modulus
+        /// @brief Box Element-wise Modulus
         ///
         /// @details Performs an element-wise modulus operation
         /// between two boxes. The boxes must have the same dimensions.
         ///
         /// @exception std::invalid_argument If the dimensions of the boxes
         /// do not match, std::invalid_argument is thrown.
-        /// 
+        ///
         /// @tparam _ElemT concept: Modulo | requires: ModuloWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
-        /// @return box<decltype(std::declval<value_type>() % std::declval<_ElemT>())> 
-        template<Modulo _ElemT>
-            requires ModuloWith<value_type, _ElemT>
-        constexpr auto mod(const box<_ElemT>& other)
+        /// @return box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
+        template <Modulo _ElemT>
+        requires ModuloWith<value_type, _ElemT>
+        constexpr auto mod(const box<_ElemT> &other)
             -> box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1454,22 +1398,21 @@ namespace cortex
             return result;
         }
 
-
-        /// @brief Scalar Box Modulus
+        /// @brief Scalar Modulus
         ///
         /// @details Performs an element-wise modulus operation
-        /// between all elements of the box and the scalar. The 
+        /// between all elements of the box and the scalar. The
         /// box must not be empty.
         ///
         /// @exception std::invalid_argument If the box is empty,
-        /// std::invalid_argument is thrown. 
-        /// 
+        /// std::invalid_argument is thrown.
+        ///
         /// @tparam _ScalarT concept: Modulo | requires: ModuloWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
-        /// @return box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())> 
-        template<Modulo _ScalarT>
-            requires ModuloWith<value_type, _ScalarT>
-        constexpr auto mod(const _ScalarT& scalar)
+        /// @return box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
+        template <Modulo _ScalarT>
+        requires ModuloWith<value_type, _ScalarT>
+        constexpr auto mod(const _ScalarT &scalar)
             -> box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1477,11 +1420,64 @@ namespace cortex
 
             box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())> result(this->rows(), this->columns());
 
-            std::ranges::transform(*this, result.begin(), [&](auto& elem){ return elem % scalar; });
+            std::ranges::transform(*this, result.begin(), [&](auto &elem)
+                                   { return elem % scalar; });
 
             return result;
         }
-        
+
+        /// @brief Box Element-wise Bitwise Xor
+        ///
+        /// @details Performs an element-wise bitwise Xor operation
+        /// between two boxes. The boxes must have the same dimensions.
+        ///
+        /// @exception std::invalid_argument If the dimensions of the boxes
+        /// do not match, std::invalid_argument is thrown.
+        ///
+        /// @tparam _ElemT concept: BitXor | requires: BitXorWith<value_type, _ElemT>
+        /// @param other type: box<_ElemT> | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
+        template <BitXor _ElemT>
+        requires BitXorWith<value_type, _ElemT>
+        constexpr auto bit_xor(const box<_ElemT> &other)
+            -> box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
+        {
+            if (this->dimensions() not_eq other.dimensions())
+                throw std::invalid_argument("In box::bit_xor - dimensions do not match");
+
+            box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, other, result.begin(), std::bit_xor{});
+
+            return result;
+        }
+
+        /// @brief Scalar Bitwise Xor
+        ///
+        /// @details Performs an element-wise bitwise Xor operation
+        /// between all elements of the box and the scalar. The
+        /// box must not be empty.
+        ///
+        /// @exception std::invalid_argument If the box is empty,
+        /// std::invalid_argument is thrown.
+        ///
+        /// @tparam _ScalarT concept: BitXor | requires: BitXorWith<value_type, _ScalarT>
+        /// @param scalar type: _ScalarT | qualifiers: [const, ref]
+        /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
+        template <BitXor _ScalarT>
+        requires BitXorWith<value_type, _ScalarT>
+        constexpr auto bit_xor(const _ScalarT &scalar)
+            -> box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
+        {
+            if (empty())
+                throw std::invalid_argument("In box::bit_xor - scalar bit_xor on empty box");
+
+            box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())> result(this->rows(), this->columns());
+
+            std::ranges::transform(*this, result.begin(), [&](auto &elem) { return elem ^ scalar; });
+
+            return result;
+        }
 
         /// @brief Matrix Transpose
         ///
@@ -1489,8 +1485,8 @@ namespace cortex
         /// Uses std::copy over std::ranges::copy as the output
         /// iterator is required to be std::constructible_v which
         /// column_iterator doesn't satisfy yet.
-        /// 
-        /// @return constexpr box<value_type> 
+        ///
+        /// @return constexpr box<value_type>
         constexpr box<value_type> transpose()
         {
             box<value_type> result(this->columns(), this->rows());
@@ -1503,49 +1499,47 @@ namespace cortex
             return result;
         }
 
-
     private:
-
         /// @brief Allocates Matrix Recources
-        /// 
-        /// @details Allocates the memory for the box 
-        /// using the allocator of the container. Uses 
+        ///
+        /// @details Allocates the memory for the box
+        /// using the allocator of the container. Uses
         /// std::allocator_traits to get the allocators
-        /// relevant methods. 
+        /// relevant methods.
         ///
         /// @note Default allocator is std::allocator<value_type>.
-        /// 
+        ///
         /// @param __n type: [size_type]
-        /// @return constexpr pointer 
+        /// @return constexpr pointer
         constexpr pointer _M_allocate(size_type __n)
-        { return __n not_eq 0 ? alloc_traits::allocate(m_allocator, __n) : pointer(); }
-
+        {
+            return __n not_eq 0 ? alloc_traits::allocate(m_allocator, __n) : pointer();
+        }
 
         /// @brief Dellocates Matrix Recources
-        /// 
-        /// @details Dellocates the memory for the box 
-        /// using the allocator of the container. Uses 
+        ///
+        /// @details Dellocates the memory for the box
+        /// using the allocator of the container. Uses
         /// std::allocator_traits to get the allocators
-        /// relevant methods. 
+        /// relevant methods.
         ///
         /// @note Default allocator is std::allocator<value_type>.
-        /// 
+        ///
         /// @param __p type: [pointer]
         /// @param __n type: [size_type] | attr: [[maybe_unused]]
         constexpr void _M_deallocate(pointer __p, [[maybe_unused]] size_type __n)
-        { 
+        {
             if (__p)
                 alloc_traits::deallocate(m_allocator, __p, __n);
         }
 
-
         /// @brief Checks index's are in the bounds of the box
-        /// 
-        /// @details Checks if __column and __row are withing 
-        /// the box's bounds. 
-        /// 
+        ///
+        /// @details Checks if __column and __row are withing
+        /// the box's bounds.
+        ///
         /// @exception std::out_of_range
-        /// 
+        ///
         /// @param __column type: [size_type]
         /// @param __row type: [size_type]
         constexpr void _M_range_check(size_type __row, size_type __column) const
@@ -1554,54 +1548,60 @@ namespace cortex
                 throw std::out_of_range("box::_M_range_check - index out of range.");
         }
 
-
         constexpr size_type _M_size(size_type __rows, size_type __columns) const noexcept
-        { return __rows * __columns not_eq 0 ? __rows * __columns : std::max(__rows, __columns); } 
-
+        {
+            return __rows * __columns not_eq 0 ? __rows * __columns : std::max(__rows, __columns);
+        }
 
         constexpr size_type _M_index(size_type __row, size_type __column) const noexcept
-        { return __row * columns() + __column; }
-
+        {
+            return __row * columns() + __column;
+        }
 
         /// @brief Returns the pointer passed to it.
-        /// 
-        /// @tparam _Up 
+        ///
+        /// @tparam _Up
         /// @param __ptr type: [_Up*]
-        /// @return _Up* 
-        template<typename _Up>
-        _Up* _M_data_ptr(_Up* __ptr) const noexcept
-        { return __ptr; }
+        /// @return _Up*
+        template <typename _Up>
+        _Up *_M_data_ptr(_Up *__ptr) const noexcept
+        {
+            return __ptr;
+        }
 
 #if __cplusplus >= 201103L
 
         /// @brief Returns the pointer passed to it.
-        /// 
-        /// @details If the value given is not a builtin 
-        /// pointer type, a pointer is created from the 
+        ///
+        /// @details If the value given is not a builtin
+        /// pointer type, a pointer is created from the
         /// underlying element type.
-        /// 
+        ///
         /// @tparam _Ptr
         /// @param __ptr type: [_Ptr]
         /// @return typename std::pointer_traits<_Ptr>::element_type*
-        template<typename _Ptr>
-        typename std::pointer_traits<_Ptr>::element_type* 
+        template <typename _Ptr>
+        typename std::pointer_traits<_Ptr>::element_type *
         _M_data_ptr(_Ptr __ptr) const
-        { return empty() ? nullptr : std::to_address(*__ptr); }
+        {
+            return empty() ? nullptr : std::to_address(*__ptr);
+        }
 #else
 
         /// @brief Returns the given pointer
-        /// 
-        /// @details Returns the pointer given to it is 
+        ///
+        /// @details Returns the pointer given to it is
         /// a builtin pointer type.
-        /// 
-        /// @tparam _Up 
-        /// @param __ptr type: [_Up*] 
+        ///
+        /// @tparam _Up
+        /// @param __ptr type: [_Up*]
         /// @return _Up*
-        template<typename _Up>
-        _Up* _M_data_ptr(_Up* __ptr) noexcept
-        { return __ptr; }
+        template <typename _Up>
+        _Up *_M_data_ptr(_Up *__ptr) noexcept
+        {
+            return __ptr;
+        }
 #endif // __cplusplus >= 201103L
-
     };
 
     /// @brief Compares two matrices for equality.
@@ -1624,24 +1624,26 @@ namespace cortex
     /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
     /// @return true
     /// @return false
-    template<typename _ElemL, typename _ElemR>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemL lhsE, _ElemR rhsE)
-        { { lhsE == rhsE } -> std::convertible_to<bool>; }
+    template <typename _ElemL, typename _ElemR>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemL lhsE, _ElemR rhsE)
+    {
+        {
+            lhsE == rhsE
+            } -> std::convertible_to<bool>;
+    }
     constexpr inline bool
-    operator== (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-        noexcept ( 
-               noexcept (std::declval<_ElemL>() == std::declval<_ElemR>()) 
-            && noexcept (std::ranges::equal(lhs, rhs);)
-        )
+    operator==(const box<_ElemL> &lhs, const box<_ElemR> &rhs) noexcept(
+        noexcept(std::declval<_ElemL>() == std::declval<_ElemR>())
+            &&noexcept(std::ranges::equal(lhs, rhs);))
 #else
     inline bool
-    operator== (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-#endif 
-    { 
+    operator==(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+#endif
+    {
         if (lhs.dimensions() not_eq rhs.dimensions())
             return false;
-        return std::ranges::equal(lhs, rhs); 
+        return std::ranges::equal(lhs, rhs);
     }
 
 /// Current bug with GCC-11.1 with lexicographical_compare_three_way
@@ -1652,22 +1654,20 @@ namespace cortex
 
     /// @brief Spaceship Operator for matrices.
     ///
-    /// @details Uses std::lexicographical_compare_three_way to 
+    /// @details Uses std::lexicographical_compare_three_way to
     /// compare the matrices and generates the !=, <, >, <=, >=
     /// operators.
-    /// 
-    /// @tparam _ElemL 
-    /// @tparam _ElemR 
+    ///
+    /// @tparam _ElemL
+    /// @tparam _ElemR
     /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
     /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
     /// @return constexpr inline auto
-    template<typename _ElemL, typename _ElemR>
+    template <typename _ElemL, typename _ElemR>
     constexpr inline auto
-    operator<=> (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-    { 
-        return std::lexicographical_compare_three_way(lhs.begin(), lhs.end()
-                                                  , rhs.begin(), rhs.end()
-                                                  , std::compare_three_way{}); 
+    operator<=>(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+    {
+        return std::lexicographical_compare_three_way(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), std::compare_three_way{});
     }
 
 #else // !C++20
@@ -1676,336 +1676,360 @@ namespace cortex
     ///
     /// @details Inverts the result of a equality comparison
     /// between two matrices.
-    /// 
-    /// @tparam _ElemL 
-    /// @tparam _ElemR 
+    ///
+    /// @tparam _ElemL
+    /// @tparam _ElemR
     /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
     /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
-    /// @return true 
-    /// @return false 
-    template<typename _ElemL, typename _ElemR>
+    /// @return true
+    /// @return false
+    template <typename _ElemL, typename _ElemR>
     inline bool
-    operator!= (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-    { return !(lhs == rhs); }
-
-
-    /// @brief Compares if a box is lexicographically 
-    /// less than another. 
-    /// 
-    /// @tparam _ElemL 
-    /// @tparam _ElemR 
-    /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
-    /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
-    /// @return true 
-    /// @return false 
-    template<typename _ElemL, typename _ElemR>
-    inline bool
-    operator< (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-    { 
-        return std::ranges::lexicographical_compare(lhs, rhs); 
+    operator!=(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+    {
+        return !(lhs == rhs);
     }
 
+    /// @brief Compares if a box is lexicographically
+    /// less than another.
+    ///
+    /// @tparam _ElemL
+    /// @tparam _ElemR
+    /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
+    /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
+    /// @return true
+    /// @return false
+    template <typename _ElemL, typename _ElemR>
+    inline bool
+    operator<(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+    {
+        return std::ranges::lexicographical_compare(lhs, rhs);
+    }
 
     /// @brief Compares if a box is lexicographically
     /// greater than another.
     ///
     /// @details Uses less than comparison and swaps the
-    /// order of the arguments. 
-    /// 
-    /// @tparam _ElemL 
-    /// @tparam _ElemR 
+    /// order of the arguments.
+    ///
+    /// @tparam _ElemL
+    /// @tparam _ElemR
     /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
     /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
-    /// @return true 
-    /// @return false 
-    template<typename _ElemL, typename _ElemR>
+    /// @return true
+    /// @return false
+    template <typename _ElemL, typename _ElemR>
     inline bool
-    operator> (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-    { return rhs < lhs; }
-
+    operator>(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+    {
+        return rhs < lhs;
+    }
 
     /// @brief Compares if a box is lexicographically
-    /// less than or equal to another. 
+    /// less than or equal to another.
     ///
     /// @details Uses less than comparison and swaps the
     /// order of the arguments. If the rhs box is less
     /// than the lhs box, then the lhs box cannot
-    /// be less then or equal to the rhs box.  
-    /// 
-    /// @tparam _ElemL 
-    /// @tparam _ElemR 
+    /// be less then or equal to the rhs box.
+    ///
+    /// @tparam _ElemL
+    /// @tparam _ElemR
     /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
     /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
-    /// @return true 
-    /// @return false 
-    template<typename _ElemL, typename _ElemR>
+    /// @return true
+    /// @return false
+    template <typename _ElemL, typename _ElemR>
     inline bool
-    operator<= (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-    { return !(rhs < lhs); }
-
+    operator<=(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+    {
+        return !(rhs < lhs);
+    }
 
     /// @brief Compares if a box is lexicographically
     /// greater than or equal to another.
     ///
     /// @details Inverts the result of a less than comparison
-    /// between the two matrices. 
-    /// 
-    /// @tparam _ElemL 
-    /// @tparam _ElemR 
+    /// between the two matrices.
+    ///
+    /// @tparam _ElemL
+    /// @tparam _ElemR
     /// @param lhs type: [box<_ElemL>] | qualifiers: [const], [ref]
     /// @param rhs type: [box<_ElemR>] | qualifiers: [const], [ref]
-    /// @return true 
-    /// @return false 
-    template<typename _ElemL, typename _ElemR>
+    /// @return true
+    /// @return false
+    template <typename _ElemL, typename _ElemR>
     inline bool
-    operator>= (const box<_ElemL>& lhs, const box<_ElemR>& rhs)
-    { return !(lhs < rhs); }
+    operator>=(const box<_ElemL> &lhs, const box<_ElemR> &rhs)
+    {
+        return !(lhs < rhs);
+    }
 
 #endif // three way compare
 
-
-    /// @brief Scalar Equality Comparison 
-    /// 
+    /// @brief Scalar Equality Comparison
+    ///
     /// @details Compares each value within the box to a given
-    /// scalar. Creates a bit mask (or boolean mask) of the values 
+    /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are equal as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support 
+    /// @requires Comparison of scalar type and box type support
     /// equality comparison that results in a bool.
     ///
-    /// @exception Operation is noexcept iff the inequlity comparison 
+    /// @exception Operation is noexcept iff the inequlity comparison
     /// between the scalar and the box element's types is noexcept.
     ///
-    /// @tparam _ElemT 
-    ///
-    /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
-    /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
-    /// @return box<bool> 
-    template<typename _ElemT>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemT lhsE, _ElemT rhsE)
-        { { lhsE == rhsE } -> std::convertible_to<bool>; }
-    constexpr inline auto
-    operator== (const box<_ElemT>& bx, const _ElemT& scalar)
-        noexcept ( noexcept ( std::declval<_ElemT>() == std::declval<_ElemT>() ) )
-        -> box<bool>
-#else
-    inline auto
-    operator== (const box<_ElemT>& bx, const _ElemT& scalar)
-        -> box<bool>
-#endif 
-    { 
-        box<bool> result(bx.rows(), bx.columns(), false);
-        std::ranges::transform(bx, result.begin(), [&](const _ElemT& bxE) { return bxE == scalar; });
-        return result;
-    }
-
-
-    /// @brief Scalar Inequality Comparison 
-    /// 
-    /// @details Compares each value within the box to a given
-    /// scalar. Creates a bit mask (or boolean mask) of the values 
-    /// that are inequal as true and the everything else as false.
-    ///
-    /// @requires Comparison of scalar type and box type support 
-    /// inequality comparison that results in a bool.
-    ///
-    /// @exception Operation is noexcept iff the inequlity comparison 
-    /// between the scalar and the box element's types is noexcept.
-    ///
-    /// @tparam _ElemT 
+    /// @tparam _ElemT
     ///
     /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
     /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
     /// @return box<bool>
-    template<typename _ElemT>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemT lhsE, _ElemT rhsE)
-        { { lhsE != rhsE } -> std::convertible_to<bool>; }
+    template <typename _ElemT>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemT lhsE, _ElemT rhsE)
+    {
+        {
+            lhsE == rhsE
+            } -> std::convertible_to<bool>;
+    }
     constexpr inline auto
-    operator!= (const box<_ElemT>& bx, const _ElemT& scalar)
-        noexcept ( noexcept ( std::declval<_ElemT>() != std::declval<_ElemT>() ) )
+    operator==(const box<_ElemT> &bx, const _ElemT &scalar) noexcept(noexcept(std::declval<_ElemT>() == std::declval<_ElemT>()))
         -> box<bool>
 #else
     inline auto
-    operator!= (const box<_ElemT>& bx, const _ElemT& scalar)
+    operator==(const box<_ElemT> &bx, const _ElemT &scalar)
         -> box<bool>
-#endif 
-    { 
+#endif
+    {
         box<bool> result(bx.rows(), bx.columns(), false);
-        std::ranges::transform(bx, result.begin(), [&](const _ElemT& bxE) { return bxE != scalar; });
+        std::ranges::transform(bx, result.begin(), [&](const _ElemT &bxE)
+                               { return bxE == scalar; });
         return result;
     }
 
-
-    /// @brief Scalar Less-Then Comparison 
-    /// 
+    /// @brief Scalar Inequality Comparison
+    ///
     /// @details Compares each value within the box to a given
-    /// scalar. Creates a bit mask (or boolean mask) of the values 
+    /// scalar. Creates a bit mask (or boolean mask) of the values
+    /// that are inequal as true and the everything else as false.
+    ///
+    /// @requires Comparison of scalar type and box type support
+    /// inequality comparison that results in a bool.
+    ///
+    /// @exception Operation is noexcept iff the inequlity comparison
+    /// between the scalar and the box element's types is noexcept.
+    ///
+    /// @tparam _ElemT
+    ///
+    /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
+    /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
+    /// @return box<bool>
+    template <typename _ElemT>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemT lhsE, _ElemT rhsE)
+    {
+        {
+            lhsE != rhsE
+            } -> std::convertible_to<bool>;
+    }
+    constexpr inline auto
+    operator!=(const box<_ElemT> &bx, const _ElemT &scalar) noexcept(noexcept(std::declval<_ElemT>() != std::declval<_ElemT>()))
+        -> box<bool>
+#else
+    inline auto
+    operator!=(const box<_ElemT> &bx, const _ElemT &scalar)
+        -> box<bool>
+#endif
+    {
+        box<bool> result(bx.rows(), bx.columns(), false);
+        std::ranges::transform(bx, result.begin(), [&](const _ElemT &bxE)
+                               { return bxE != scalar; });
+        return result;
+    }
+
+    /// @brief Scalar Less-Then Comparison
+    ///
+    /// @details Compares each value within the box to a given
+    /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are less-than as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support 
+    /// @requires Comparison of scalar type and box type support
     /// less-than comparison that results in a bool.
     ///
-    /// @exception Operation is noexcept iff the less-than comparison 
+    /// @exception Operation is noexcept iff the less-than comparison
     /// between the scalar and the box element's types is noexcept.
     ///
-    /// @tparam _ElemT 
+    /// @tparam _ElemT
     ///
     /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
     /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
-    /// @return box<bool> 
-    template<typename _ElemT>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemT lhsE, _ElemT rhsE)
-        { { lhsE < rhsE } -> std::convertible_to<bool>; }
+    /// @return box<bool>
+    template <typename _ElemT>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemT lhsE, _ElemT rhsE)
+    {
+        {
+            lhsE < rhsE
+            } -> std::convertible_to<bool>;
+    }
     constexpr inline auto
-    operator< (const box<_ElemT>& bx, const _ElemT& scalar)
-        noexcept ( noexcept ( std::declval<_ElemT>() < std::declval<_ElemT>() ) )
+    operator<(const box<_ElemT> &bx, const _ElemT &scalar) noexcept(noexcept(std::declval<_ElemT>() < std::declval<_ElemT>()))
         -> box<bool>
 #else
     inline auto
-    operator< (const box<_ElemT>& bx, const _ElemT& scalar)
+    operator<(const box<_ElemT> &bx, const _ElemT &scalar)
         -> box<bool>
-#endif 
-    { 
+#endif
+    {
         box<bool> result(bx.rows(), bx.columns(), false);
-        std::ranges::transform(bx, result.begin(), [&](const _ElemT& bxE) { return bxE < scalar; });
+        std::ranges::transform(bx, result.begin(), [&](const _ElemT &bxE)
+                               { return bxE < scalar; });
         return result;
     }
 
-
-    /// @brief Scalar Greater-Then Comparison 
-    /// 
+    /// @brief Scalar Greater-Then Comparison
+    ///
     /// @details Compares each value within the box to a given
-    /// scalar. Creates a bit mask (or boolean mask) of the values 
+    /// scalar. Creates a bit mask (or boolean mask) of the values
     /// that are greater-than as true and the everything else as false.
     ///
-    /// @requires Comparison of scalar type and box type support 
+    /// @requires Comparison of scalar type and box type support
     /// greater-than comparison that results in a bool.
     ///
-    /// @exception Operation is noexcept iff the greater-than comparison 
+    /// @exception Operation is noexcept iff the greater-than comparison
     /// between the scalar and the box element's types is noexcept.
     ///
-    /// @tparam _ElemT 
+    /// @tparam _ElemT
     ///
     /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
     /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
-    /// @return box<bool> 
-    template<typename _ElemT>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemT lhsE, _ElemT rhsE)
-        { { lhsE > rhsE } -> std::convertible_to<bool>; }
+    /// @return box<bool>
+    template <typename _ElemT>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemT lhsE, _ElemT rhsE)
+    {
+        {
+            lhsE > rhsE
+            } -> std::convertible_to<bool>;
+    }
     constexpr inline auto
-    operator> (const box<_ElemT>& bx, const _ElemT& scalar)
-        noexcept ( noexcept ( std::declval<_ElemT>() > std::declval<_ElemT>() ) )
+    operator>(const box<_ElemT> &bx, const _ElemT &scalar) noexcept(noexcept(std::declval<_ElemT>() > std::declval<_ElemT>()))
         -> box<bool>
 #else
     inline auto
-    operator> (const box<_ElemT>& bx, const _ElemT& scalar)
+    operator>(const box<_ElemT> &bx, const _ElemT &scalar)
         -> box<bool>
-#endif 
-    { 
+#endif
+    {
         box<bool> result(bx.rows(), bx.columns(), false);
-        std::ranges::transform(bx, result.begin(), [&](const _ElemT& bxE) { return bxE > scalar; });
+        std::ranges::transform(bx, result.begin(), [&](const _ElemT &bxE)
+                               { return bxE > scalar; });
         return result;
     }
 
-
-    /// @brief Scalar Less-Then-Equal Comparison 
-    /// 
+    /// @brief Scalar Less-Then-Equal Comparison
+    ///
     /// @details Compares each value within the box to a given
-    /// scalar. Creates a bit mask (or boolean mask) of the values 
-    /// that are less-than-eqaul as true and the everything else as 
+    /// scalar. Creates a bit mask (or boolean mask) of the values
+    /// that are less-than-eqaul as true and the everything else as
     /// false.
     ///
-    /// @requires Comparison of scalar type and box type support 
+    /// @requires Comparison of scalar type and box type support
     /// less-than comparison that results in a bool.
     ///
-    /// @exception Operation is noexcept iff the less-than-equal comparison 
+    /// @exception Operation is noexcept iff the less-than-equal comparison
     /// between the scalar and the box element's types is noexcept.
     ///
-    /// @tparam _ElemT 
+    /// @tparam _ElemT
     ///
     /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
     /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
-    /// @return box<bool> 
-    template<typename _ElemT>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemT lhsE, _ElemT rhsE)
-        { { lhsE <= rhsE } -> std::convertible_to<bool>; }
+    /// @return box<bool>
+    template <typename _ElemT>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemT lhsE, _ElemT rhsE)
+    {
+        {
+            lhsE <= rhsE
+            } -> std::convertible_to<bool>;
+    }
     constexpr inline auto
-    operator<= (const box<_ElemT>& bx, const _ElemT& scalar)
-        noexcept ( noexcept ( std::declval<_ElemT>() > std::declval<_ElemT>() ) )
+    operator<=(const box<_ElemT> &bx, const _ElemT &scalar) noexcept(noexcept(std::declval<_ElemT>() > std::declval<_ElemT>()))
         -> box<bool>
 #else
     inline auto
-    operator<= (const box<_ElemT>& bx, const _ElemT& scalar)
+    operator<=(const box<_ElemT> &bx, const _ElemT &scalar)
         -> box<bool>
-#endif 
-    { 
+#endif
+    {
         box<bool> result(bx.rows(), bx.columns(), false);
-        std::ranges::transform(bx, result.begin(), [&](const _ElemT& bxE) { return bxE <= scalar; });
+        std::ranges::transform(bx, result.begin(), [&](const _ElemT &bxE)
+                               { return bxE <= scalar; });
         return result;
     }
 
-
-    /// @brief Scalar Greater-Then-Equal Comparison 
-    /// 
+    /// @brief Scalar Greater-Then-Equal Comparison
+    ///
     /// @details Compares each value within the box to a given
-    /// scalar. Creates a bit mask (or boolean mask) of the values 
-    /// that are greater-than-equal as true and the everything else 
+    /// scalar. Creates a bit mask (or boolean mask) of the values
+    /// that are greater-than-equal as true and the everything else
     /// as false.
     ///
-    /// @requires Comparison of scalar type and box type support 
+    /// @requires Comparison of scalar type and box type support
     /// greater-than-equal comparison that results in a bool.
     ///
-    /// @exception Operation is noexcept iff the greater-than-equal 
-    /// comparison between the scalar and the box element's types 
+    /// @exception Operation is noexcept iff the greater-than-equal
+    /// comparison between the scalar and the box element's types
     /// is noexcept.
     ///
-    /// @tparam _ElemT 
+    /// @tparam _ElemT
     ///
     /// @param bx type: [box<_ElemT>] | qualifiers: [const], [ref]
     /// @param scalar type: [_ElemT] | qualifiers: [const], [ref]
-    /// @return box<bool> 
-    template<typename _ElemT>
-#if __cpluscplus >= 202002L 
-        requires requires (_ElemT lhsE, _ElemT rhsE)
-        { { lhsE >= rhsE } -> std::convertible_to<bool>; }
+    /// @return box<bool>
+    template <typename _ElemT>
+#if __cpluscplus >= 202002L
+    requires requires(_ElemT lhsE, _ElemT rhsE)
+    {
+        {
+            lhsE >= rhsE
+            } -> std::convertible_to<bool>;
+    }
     constexpr inline auto
-    operator>= (const box<_ElemT>& bx, const _ElemT& scalar)
-        noexcept ( noexcept ( std::declval<_ElemT>() > std::declval<_ElemT>() ) )
+    operator>=(const box<_ElemT> &bx, const _ElemT &scalar) noexcept(noexcept(std::declval<_ElemT>() > std::declval<_ElemT>()))
         -> box<bool>
 #else
     inline auto
-    operator>= (const box<_ElemT>& bx, const _ElemT& scalar)
+    operator>=(const box<_ElemT> &bx, const _ElemT &scalar)
         -> box<bool>
-#endif 
-    { 
+#endif
+    {
         box<bool> result(bx.rows(), bx.columns(), false);
-        std::ranges::transform(bx, result.begin(), [&](const _ElemT& bxE) { return bxE >= scalar; });
+        std::ranges::transform(bx, result.begin(), [&](const _ElemT &bxE)
+                               { return bxE >= scalar; });
         return result;
     }
 
 } // namespace cortex
 
 namespace std
-{   
-    /// @brief Uses std::swaps to swap the contents of two matrices. 
+{
+    /// @brief Uses std::swaps to swap the contents of two matrices.
     ///
-    /// @details Swaps the contents of two matrices if they are of 
+    /// @details Swaps the contents of two matrices if they are of
     /// the same type.
     ///
     /// @exception std::swap is noexcept if __x.swap(__y) is noexcept.
-    /// 
-    /// @tparam _Tp 
+    ///
+    /// @tparam _Tp
     /// @param __x type: [cortex::box<_Tp>] | qualifiers: [const], [ref]
     /// @param __y type: [cortex::box<_Tp>] | qualifiers: [const], [ref]
     /// @return inline void
-    template<typename _Tp>
-    inline void swap(cortex::box<_Tp>& x, cortex::box<_Tp>& y) noexcept
-    { x.swap(y); }
+    template <typename _Tp>
+    inline void swap(cortex::box<_Tp> &x, cortex::box<_Tp> &y) noexcept
+    {
+        x.swap(y);
+    }
 }
 
 #endif // __cplusplus >= 201703L

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -3,7 +3,7 @@
 /// @file box
 /// @author Tyler Swann (oraqlle@github.com)
 /// @brief Two Dimensional Access To Contiguous Data
-/// @version 2.0.3 ..
+/// @version 2.0.5 ..
 /// @date 2022-16-22
 ///
 /// @copyright Copyright (c) 2022
@@ -38,10 +38,10 @@ namespace cortex
     /// viewed as a series of rows and columns.
     ///
     /// @todo Add support for iterator constructors -------------------------- ✔️
+    /// @todo Add other modification methods (mod, xor etc.) ----------------- ✔️
     /// @todo Projection method ---------------------------------------------- 🗑️ (do-able with assign)
     /// @todo Add support for single initialiser constructor ----------------- 🗑️ (too ambiguous for compiler)
     /// @todo Add support for assign -----------------------------------------
-    /// @todo Add other modification methods (mod, xor etc.) -----------------
     /// @todo Add support for operator overloads -----------------------------
     /// @todo Add flips ------------------------------------------------------
     /// @todo Add rotates ----------------------------------------------------
@@ -1193,7 +1193,7 @@ namespace cortex
         /// is the sum of the two input matrices element types.
         template <Addable _ElemT>
         requires AddableWith<value_type, _ElemT>
-        constexpr auto add(const box<_ElemT> &other)
+        constexpr auto add(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() + std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1226,7 +1226,7 @@ namespace cortex
         /// is the difference of the two input matrices element types.
         template <Subtractable _ElemT>
         requires SubtractableWith<value_type, _ElemT>
-        constexpr auto sub(const box<_ElemT> &other)
+        constexpr auto sub(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() - std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1259,7 +1259,7 @@ namespace cortex
         /// is the product of the two input matrices element types.
         template <Multiplicable _ElemT>
         requires MultiplicableWith<value_type, _ElemT>
-        constexpr auto mul(const box<_ElemT> &other)
+        constexpr auto mul(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() * std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1287,7 +1287,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
         template <Multiplicable _ScalarT>
         requires MultiplicableWith<value_type, _ScalarT>
-        constexpr auto mul(const _ScalarT &scalar)
+        constexpr auto mul(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() * std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1324,7 +1324,7 @@ namespace cortex
         /// is the quotient of the two input matrices element types.
         template <Divisible _ElemT>
         requires DivisibleWith<value_type, _ElemT>
-        constexpr auto div(const box<_ElemT> &other)
+        constexpr auto div(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() / std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1355,7 +1355,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
         template <Divisible _ScalarT>
         requires DivisibleWith<value_type, _ScalarT>
-        constexpr auto div(const _ScalarT &scalar)
+        constexpr auto div(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() / std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1383,7 +1383,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
         template <Modulo _ElemT>
         requires ModuloWith<value_type, _ElemT>
-        constexpr auto mod(const box<_ElemT> &other)
+        constexpr auto mod(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1410,7 +1410,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
         template <Modulo _ScalarT>
         requires ModuloWith<value_type, _ScalarT>
-        constexpr auto mod(const _ScalarT &scalar)
+        constexpr auto mod(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1436,7 +1436,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
         template <BitXor _ElemT>
         requires BitXorWith<value_type, _ElemT>
-        constexpr auto bit_xor(const box<_ElemT> &other)
+        constexpr auto bit_xor(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1463,7 +1463,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
         template <BitXor _ScalarT>
         requires BitXorWith<value_type, _ScalarT>
-        constexpr auto bit_xor(const _ScalarT &scalar)
+        constexpr auto bit_xor(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1490,7 +1490,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
         template <BitAnd _ElemT>
         requires BitAndWith<value_type, _ElemT>
-        constexpr auto bit_and(const box<_ElemT> &other)
+        constexpr auto bit_and(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1517,7 +1517,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
         template <BitAnd _ScalarT>
         requires BitAndWith<value_type, _ScalarT>
-        constexpr auto bit_and(const _ScalarT &scalar)
+        constexpr auto bit_and(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1544,7 +1544,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
         template <BitOr _ElemT>
         requires BitOrWith<value_type, _ElemT>
-        constexpr auto bit_or(const box<_ElemT> &other)
+        constexpr auto bit_or(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1571,7 +1571,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
         template <BitOr _ScalarT>
         requires BitOrWith<value_type, _ScalarT>
-        constexpr auto bit_or(const _ScalarT &scalar)
+        constexpr auto bit_or(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1598,7 +1598,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
         template <LeftBitShift _ElemT>
         requires LeftBitShiftWith<value_type, _ElemT>
-        constexpr auto shift_left(const box<_ElemT> &other)
+        constexpr auto shift_left(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1625,7 +1625,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
         template <LeftBitShift _ScalarT>
         requires LeftBitShiftWith<value_type, _ScalarT>
-        constexpr auto shift_left(const _ScalarT &scalar)
+        constexpr auto shift_left(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1652,7 +1652,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
         template <RightBitShift _ElemT>
         requires RightBitShiftWith<value_type, _ElemT>
-        constexpr auto shift_right(const box<_ElemT> &other)
+        constexpr auto shift_right(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
         {
             if (this->dimensions() not_eq other.dimensions())
@@ -1679,7 +1679,7 @@ namespace cortex
         /// @return box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
         template <RightBitShift _ScalarT>
         requires RightBitShiftWith<value_type, _ScalarT>
-        constexpr auto shift_right(const _ScalarT &scalar)
+        constexpr auto shift_right(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
         {
             if (empty())
@@ -1704,7 +1704,7 @@ namespace cortex
         /// @requires BitNot<value_type>
         ///
         /// @return box<~value_type>
-        constexpr auto bit_not() requires BitNot<value_type>
+        constexpr auto bit_not() const requires BitNot<value_type>
         {
             if (empty())
                 throw std::invalid_argument("In box::bit_not - bit_not on empty box");
@@ -2248,7 +2248,56 @@ namespace cortex
         return result;
     }
 
+
+    /// @brief Addition Operator
+    ///
+    /// @detail Operator overload for `+` operator.
+    /// Calls lx `add` method on rx and returns 
+    /// the result. 
+    /// 
+    /// @tparam _LxT 
+    /// @tparam _RxT 
+    /// @param lx type: box<_LxT> | qualifiers: [const, ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr auto 
+    template<typename _LxT, typename _RxT>
+    constexpr auto
+    operator+ (const box<_LxT>& lx, const box<_RxT>& rx)
+    { return lx.add(rx); }
+
+
+    /// @brief Additon Assignment Operator
+    ///
+    /// @details Operator overload for `+=` operator.
+    /// Calls lx `add` method on rx and assigns the result 
+    /// to lx.
+    ///
+    /// @note The left-hand-side box is mutable.
+    /// @note The left-hand-side boxes type but be
+    /// able to to store the resulting type of the
+    /// call to `add`.
+    ///
+    /// @exception std::invalid_argument Thrown if the left-hand-side
+    /// box cannot store the resulting type of the call to `add`.
+    /// 
+    /// @tparam _LxT concept: Addable
+    /// @tparam _RxT concept: Addable
+    /// @param lx type: box<_LxT> | qualifiers: [ref]
+    /// @param rx type: box<_RxT> | qualifiers: [const, ref]
+    /// @return constexpr void
+    template<Addable _LxT, Addable _RxT>
+    constexpr void
+    operator+= (box<_LxT>& lx, const box<_RxT>& rx) 
+    { 
+        if constexpr (!std::same_as<decltype(std::declval<box<_LxT>>().add(std::declval<box<_RxT>>())), box<_LxT>>)
+            throw std::invalid_argument("operator+=: left-hand-side box type cannot store the resulting type of the call to `add`.");
+        else
+            lx = lx.add(rx);
+    }
+
 } // namespace cortex
+
+
 
 namespace std
 {
@@ -2257,7 +2306,7 @@ namespace std
     /// @details Swaps the contents of two matrices if they are of
     /// the same type.
     ///
-    /// @exception std::swap is noexcept if __x.swap(__y) is noexcept.
+    /// @exception std::swap is noexcept if x.swap(y) is noexcept.
     ///
     /// @tparam _Tp
     /// @param __x type: [cortex::box<_Tp>] | qualifiers: [const], [ref]

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -1381,7 +1381,7 @@ namespace cortex
         /// @tparam _ElemT concept: Modulo |     requires: ModuloWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
-        template <Modulo _ElemT>
+        template <Any _ElemT>
             requires ModuloWith<value_type, _ElemT>
         constexpr auto mod(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() % std::declval<_ElemT>())>
@@ -1408,7 +1408,7 @@ namespace cortex
         /// @tparam _ScalarT concept: Modulo |     requires: ModuloWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
-        template <Modulo _ScalarT>
+        template <Any _ScalarT>
             requires ModuloWith<value_type, _ScalarT>
         constexpr auto mod(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() % std::declval<_ScalarT>())>
@@ -1434,7 +1434,7 @@ namespace cortex
         /// @tparam _ElemT concept: BitXor |     requires: BitXorWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
-        template <BitXor _ElemT>
+        template <Any _ElemT>
             requires BitXorWith<value_type, _ElemT>
         constexpr auto bit_xor(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() ^ std::declval<_ElemT>())>
@@ -1461,7 +1461,7 @@ namespace cortex
         /// @tparam _ScalarT concept: BitXor |     requires: BitXorWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
-        template <BitXor _ScalarT>
+        template <Any _ScalarT>
             requires BitXorWith<value_type, _ScalarT>
         constexpr auto bit_xor(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() ^ std::declval<_ScalarT>())>
@@ -1488,7 +1488,7 @@ namespace cortex
         /// @tparam _ElemT concept: BitAnd |     requires: BitAndWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
-        template <BitAnd _ElemT>
+        template <Any _ElemT>
             requires BitAndWith<value_type, _ElemT>
         constexpr auto bit_and(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() & std::declval<_ElemT>())>
@@ -1515,7 +1515,7 @@ namespace cortex
         /// @tparam _ScalarT concept: BitAnd |     requires: BitAndWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
-        template <BitAnd _ScalarT>
+        template <Any _ScalarT>
             requires BitAndWith<value_type, _ScalarT>
         constexpr auto bit_and(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() & std::declval<_ScalarT>())>
@@ -1542,7 +1542,7 @@ namespace cortex
         /// @tparam _ElemT concept: BitOr |     requires: BitOrWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
-        template <BitOr _ElemT>
+        template <Any _ElemT>
             requires BitOrWith<value_type, _ElemT>
         constexpr auto bit_or(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() | std::declval<_ElemT>())>
@@ -1569,7 +1569,7 @@ namespace cortex
         /// @tparam _ScalarT concept: BitOr |     requires: BitOrWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
-        template <BitOr _ScalarT>
+        template <Any _ScalarT>
             requires BitOrWith<value_type, _ScalarT>
         constexpr auto bit_or(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() | std::declval<_ScalarT>())>
@@ -1596,7 +1596,7 @@ namespace cortex
         /// @tparam _ElemT concept: LeftBitShift |     requires: LeftBitShiftWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
-        template <LeftBitShift _ElemT>
+        template <Any _ElemT>
             requires LeftBitShiftWith<value_type, _ElemT>
         constexpr auto shift_left(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() << std::declval<_ElemT>())>
@@ -1623,7 +1623,7 @@ namespace cortex
         /// @tparam _ScalarT concept: LeftBitShift |     requires: LeftBitShiftWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
-        template <LeftBitShift _ScalarT>
+        template <Any _ScalarT>
             requires LeftBitShiftWith<value_type, _ScalarT>
         constexpr auto shift_left(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() << std::declval<_ScalarT>())>
@@ -1650,7 +1650,7 @@ namespace cortex
         /// @tparam _ElemT concept: RightBitShift |     requires: RightBitShiftWith<value_type, _ElemT>
         /// @param other type: box<_ElemT> | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
-        template <RightBitShift _ElemT>
+        template <Any _ElemT>
             requires RightBitShiftWith<value_type, _ElemT>
         constexpr auto shift_right(const box<_ElemT> &other) const
             -> box<decltype(std::declval<value_type>() >> std::declval<_ElemT>())>
@@ -1677,7 +1677,7 @@ namespace cortex
         /// @tparam _ScalarT concept: RightBitShift |     requires: RightBitShiftWith<value_type, _ScalarT>
         /// @param scalar type: _ScalarT | qualifiers: [const, ref]
         /// @return box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
-        template <RightBitShift _ScalarT>
+        template <Any _ScalarT>
             requires RightBitShiftWith<value_type, _ScalarT>
         constexpr auto shift_right(const _ScalarT &scalar) const
             -> box<decltype(std::declval<value_type>() >> std::declval<_ScalarT>())>
@@ -1703,7 +1703,7 @@ namespace cortex
         ///
         /// @    requires BitNot<value_type>
         ///
-        /// @return box<~value_type>
+        /// @return constexpr auto
         constexpr auto bit_not() const
             requires BitNot<value_type>
         {
@@ -2439,7 +2439,7 @@ namespace cortex
     /// @note The left-hand-side box is mutable.
     /// @note The left-hand-side boxes type must be
     /// able to to store the resulting type of the
-    
+
     ///
     /// @tparam _ElemT concept: Any
     /// @tparam _ScalarT concept: Any

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -1738,6 +1738,24 @@ namespace cortex
             return result;
         }
 
+
+        /// @brief 
+        /// 
+        /// @tparam F 
+        /// @param func 
+        /// @return requires constexpr 
+        template<std::copy_constructible F>
+        constexpr auto
+        map(F func)
+        {
+            box<decltype(std::invoke(std::declval<F>(), std::declval<value_type>()))> result(this->rows(), this->columns());
+
+            if (not empty())
+                std::ranges::transform(*this, result.begin(), func);
+                
+            return result;
+        }
+
     private:
         /// @brief Allocates Matrix Recources
         ///
@@ -3176,6 +3194,12 @@ namespace cortex
     constexpr auto
     operator! (box<_ElemT> bx)
     { return bx.transpose(); }
+
+
+    template<Any _ElemT, std::copy_constructible F>
+    constexpr auto
+    operator|| (box<_ElemT> bx, F f)
+    { return bx.map(f); }
 
 } // namespace cortex
 

--- a/src/test/methods.test.cpp
+++ b/src/test/methods.test.cpp
@@ -464,7 +464,7 @@ TEST_CASE("Modulo Operator")
                 REQUIRE(elem == 0);
         }
 
-        SECTION("Non `modiplicible` or `modiplicibleWith` type")
+        SECTION("Non `Modulo` or `ModuloWith` type")
         {
             using namespace std::string_literals;
 
@@ -585,6 +585,390 @@ TEST_CASE("Bit Arithmatic Methods")
 
             for (auto& elem : rbx)
                 REQUIRE(elem == 9);
+        }
+    }
+
+    SECTION("box::bit_and")
+    {
+        SECTION("Same type")
+        {
+            cortex::box<int> bx(4, 5, 2);
+            cortex::box<int> nbx(4, 5, 5);
+            cortex::box<int> rbxcheck(4, 5, 0);
+
+            auto rbx { bx.bit_and(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 2);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 5);
+            
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Different type")
+        {
+            cortex::box<int> bx(4, 5, 7);
+            cortex::box<std::size_t> nbx(4, 5, 4uL);
+            cortex::box<decltype(int() & std::size_t())> rbxcheck(4, 5, 4);
+
+            auto rbx { bx.bit_and(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 7);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 4uL);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 4uL);
+        }
+
+        SECTION("Same Matrix")
+        {
+            cortex::box<int> bx(4, 5, 10);
+            cortex::box<int> rbxcheck(4, 5, 10);
+
+            auto rbx { bx.bit_and(bx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 10);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 10);
+        }
+
+        SECTION("Same Matrix + Assign")
+        {
+            cortex::box<int> bx(4, 5, 5);
+            cortex::box<int> bxcheck(4, 5, 5);
+
+            bx = bx.bit_and(bx);
+
+            REQUIRE(bx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 5);
+        }
+
+        SECTION("Non `BitAnd` or `BitAndWith` type")
+        {
+            using namespace std::string_literals;
+
+            cortex::box<std::string> bx(0, 10, "hello"s);
+            cortex::box<std::wstring> nbx(4, 5, L"world"s);
+
+            /// To test, uncomment and code should not compile
+            // auto rbx { bx.bit_and(nbx) };
+        }
+
+        SECTION("Scalar And")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, 6);
+
+            auto rbx { bx.bit_and(6) };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 6);
+        }
+    }
+
+    SECTION("box::bit_or")
+    {
+        SECTION("Same type")
+        {
+            cortex::box<int> bx(4, 5, 2);
+            cortex::box<int> nbx(4, 5, 5);
+            cortex::box<int> rbxcheck(4, 5, 7);
+
+            auto rbx { bx.bit_or(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 2);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 5);
+            
+            for (auto& elem : rbx)
+                REQUIRE(elem == 7);
+        }
+
+        SECTION("Different type")
+        {
+            cortex::box<int> bx(4, 5, 7);
+            cortex::box<std::size_t> nbx(4, 5, 4uL);
+            cortex::box<decltype(int() | std::size_t())> rbxcheck(4, 5, 7);
+
+            auto rbx { bx.bit_or(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 7);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 4uL);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 7uL);
+        }
+
+        SECTION("Same Matrix")
+        {
+            cortex::box<int> bx(4, 5, 10);
+            cortex::box<int> rbxcheck(4, 5, 10);
+
+            auto rbx { bx.bit_or(bx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 10);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 10);
+        }
+
+        SECTION("Same Matrix + Assign")
+        {
+            cortex::box<int> bx(4, 5, 5);
+            cortex::box<int> bxcheck(4, 5, 5);
+
+            bx = bx.bit_or(bx);
+
+            REQUIRE(bx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 5);
+        }
+
+        SECTION("Non `BitOr` or `BitOrWith` type")
+        {
+            using namespace std::string_literals;
+
+            cortex::box<std::string> bx(0, 10, "hello"s);
+            cortex::box<std::wstring> nbx(4, 5, L"world"s);
+
+            /// To test, uncomment and code should not compile
+            // auto rbx { bx.bit_or(nbx) };
+        }
+
+        SECTION("Scalar Or")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, 15);
+
+            auto rbx { bx.bit_or(6) };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 15);
+        }
+    }
+
+    SECTION("box::shift_left")
+    {
+        SECTION("Same type")
+        {
+            cortex::box<int> bx(4, 5, 2);
+            cortex::box<int> nbx(4, 5, 5);
+            cortex::box<int> rbxcheck(4, 5, 64);
+
+            auto rbx { bx.shift_left(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 2);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 5);
+            
+            for (auto& elem : rbx)
+                REQUIRE(elem == 64);
+        }
+
+        SECTION("Different type")
+        {
+            cortex::box<int> bx(4, 5, 7);
+            cortex::box<std::size_t> nbx(4, 5, 4uL);
+            cortex::box<decltype(int() << std::size_t())> rbxcheck(4, 5, 112);
+
+            auto rbx { bx.shift_left(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 7);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 4uL);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 112uL);
+        }
+
+        SECTION("Same Matrix")
+        {
+            cortex::box<int> bx(4, 5, 10);
+            cortex::box<int> rbxcheck(4, 5, 10240);
+
+            auto rbx { bx.shift_left(bx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 10);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 10240);
+        }
+
+        SECTION("Same Matrix + Assign")
+        {
+            cortex::box<int> bx(4, 5, 5);
+            cortex::box<int> bxcheck(4, 5, 160);
+
+            bx = bx.shift_left(bx);
+
+            REQUIRE(bx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 160);
+        }
+
+        SECTION("Non `RightBitShift` or `RightBitShiftWith` type")
+        {
+            using namespace std::string_literals;
+
+            cortex::box<std::string> bx(0, 10, "hello"s);
+            cortex::box<std::wstring> nbx(4, 5, L"world"s);
+
+            /// To test, uncomment and code should not compile
+            // auto rbx { bx.left_bitshift(nbx) };
+        }
+
+        SECTION("Scalar Right Bit Shift")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, 960);
+
+            auto rbx { bx.shift_left(6) };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 960);
+        }
+    }
+
+    SECTION("box::shift_right")
+    {
+        SECTION("Same type")
+        {
+            cortex::box<int> bx(4, 5, 2);
+            cortex::box<int> nbx(4, 5, 5);
+            cortex::box<int> rbxcheck(4, 5, 0);
+
+            auto rbx { bx.shift_right(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 2);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 5);
+            
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Different type")
+        {
+            cortex::box<int> bx(4, 5, 7);
+            cortex::box<std::size_t> nbx(4, 5, 4uL);
+            cortex::box<decltype(int() >> std::size_t())> rbxcheck(4, 5, 0);
+
+            auto rbx { bx.shift_right(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 7);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 4uL);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0uL);
+        }
+
+        SECTION("Same Matrix")
+        {
+            cortex::box<int> bx(4, 5, 10);
+            cortex::box<int> rbxcheck(4, 5, 0);
+
+            auto rbx { bx.shift_right(bx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 10);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Same Matrix + Assign")
+        {
+            cortex::box<int> bx(4, 5, 5);
+            cortex::box<int> bxcheck(4, 5, 0);
+
+            bx = bx.shift_right(bx);
+
+            REQUIRE(bx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Non `LeftBitShift` or `LeftBitShiftWith` type")
+        {
+            using namespace std::string_literals;
+
+            cortex::box<std::string> bx(0, 10, "hello"s);
+            cortex::box<std::wstring> nbx(4, 5, L"world"s);
+
+            /// To test, uncomment and code should not compile
+            // auto rbx { bx.right_bitshift(nbx) };
+        }
+
+        SECTION("Scalar Left Bit Shift")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, 0);
+
+            auto rbx { bx.shift_right(6) };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0);
         }
     }
 }

--- a/src/test/methods.test.cpp
+++ b/src/test/methods.test.cpp
@@ -248,7 +248,7 @@ TEST_CASE("Arithmatic Methods")
                 REQUIRE(elem == 25);
         }
 
-        SECTION("Non `muliplicible` or `muliplicibleWith` type")
+        SECTION("Non `Mliplicible` or `MuliplicibleWith` type")
         {
             using namespace std::string_literals;
 
@@ -273,7 +273,7 @@ TEST_CASE("Arithmatic Methods")
         }
     }
 
-     SECTION("box::div")
+    SECTION("box::div")
     {
         SECTION("Same type")
         {
@@ -364,7 +364,7 @@ TEST_CASE("Arithmatic Methods")
                 REQUIRE(elem == 1);
         }
 
-        SECTION("Non `diviplicible` or `diviplicibleWith` type")
+        SECTION("Non `Divisible` or `DivisibleWith` type")
         {
             using namespace std::string_literals;
 
@@ -386,6 +386,102 @@ TEST_CASE("Arithmatic Methods")
 
             for (auto& elem : rbx)
                 REQUIRE(elem == 2.5);
+        }
+    }
+
+    SECTION("box::mod")
+    {
+        SECTION("Same type")
+        {
+            cortex::box<int> bx(4, 5, 2);
+            cortex::box<int> nbx(4, 5, 5);
+            cortex::box<int> rbxcheck(4, 5, 2 % 5);
+
+            auto rbx { bx.mod(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 2);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 5);
+            
+            for (auto& elem : rbx)
+                REQUIRE(elem == 2 % 5);
+        }
+
+        SECTION("Different type")
+        {
+            cortex::box<int> bx(4, 5, 7);
+            cortex::box<std::size_t> nbx(4, 5, 4uL);
+            cortex::box<double> rbxcheck(4, 5, 3);
+
+            auto rbx { bx.mod(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 7);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 4uL);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 3);
+        }
+
+        SECTION("Same Matrix")
+        {
+            cortex::box<int> bx(4, 5, 10);
+            cortex::box<int> rbxcheck(4, 5, 0);
+
+            auto rbx { bx.mod(bx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 10);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Same Matrix + Assign")
+        {
+            cortex::box<int> bx(4, 5, 5);
+            cortex::box<int> bxcheck(4, 5, 0);
+
+            bx = bx.mod(bx);
+
+            REQUIRE(bx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Non `modiplicible` or `modiplicibleWith` type")
+        {
+            using namespace std::string_literals;
+
+            cortex::box<std::string> bx(0, 10, "hello"s);
+            cortex::box<std::wstring> nbx(4, 5, L"world"s);
+
+            /// To test, uncomment and code should not compile
+            // auto rbx { bx.mod(nbx) };
+        }
+
+        SECTION("Scalar Modulo")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, 3);
+
+            auto rbx { bx.mod(6) };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 3);
         }
     }
 }

--- a/src/test/methods.test.cpp
+++ b/src/test/methods.test.cpp
@@ -971,4 +971,23 @@ TEST_CASE("Bit Arithmatic Methods")
                 REQUIRE(elem == 0);
         }
     }
+
+    SECTION("box::bit_not")
+    {
+        SECTION("Bit Not")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, -16);
+
+            auto rbx { bx.bit_not() };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 15);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == -16);
+        }
+    }
 }

--- a/src/test/methods.test.cpp
+++ b/src/test/methods.test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+#include <iostream>
 #include <box.hpp>
 
 TEST_CASE("Arithmatic Methods")
@@ -248,7 +249,7 @@ TEST_CASE("Arithmatic Methods")
                 REQUIRE(elem == 25);
         }
 
-        SECTION("Non `Mliplicible` or `MuliplicibleWith` type")
+        SECTION("Non `Multiplicible` or `MultiplicibleWith` type")
         {
             using namespace std::string_literals;
 
@@ -388,7 +389,10 @@ TEST_CASE("Arithmatic Methods")
                 REQUIRE(elem == 2.5);
         }
     }
+}
 
+TEST_CASE("Modulo Operator")
+{
     SECTION("box::mod")
     {
         SECTION("Same type")
@@ -482,6 +486,105 @@ TEST_CASE("Arithmatic Methods")
 
             for (auto& elem : rbx)
                 REQUIRE(elem == 3);
+        }
+    }
+}
+
+TEST_CASE("Bit Arithmatic Methods")
+{
+    SECTION("box::bit_xor")
+    {
+        SECTION("Same type")
+        {
+            cortex::box<int> bx(4, 5, 2);
+            cortex::box<int> nbx(4, 5, 5);
+            cortex::box<int> rbxcheck(4, 5, 7);
+
+            auto rbx { bx.bit_xor(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 2);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 5);
+            
+            for (auto& elem : rbx)
+                REQUIRE(elem == 7);
+        }
+
+        SECTION("Different type")
+        {
+            cortex::box<int> bx(4, 5, 7);
+            cortex::box<std::size_t> nbx(4, 5, 4uL);
+            cortex::box<decltype(int() ^ std::size_t())> rbxcheck(4, 5, 3);
+
+            auto rbx { bx.bit_xor(nbx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 7);
+            
+            for (auto& elem : nbx)
+                REQUIRE(elem == 4uL);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 3uL);
+        }
+
+        SECTION("Same Matrix")
+        {
+            cortex::box<int> bx(4, 5, 10);
+            cortex::box<int> rbxcheck(4, 5, 0);
+
+            auto rbx { bx.bit_xor(bx) };
+
+            REQUIRE(rbx == rbxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 10);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Same Matrix + Assign")
+        {
+            cortex::box<int> bx(4, 5, 5);
+            cortex::box<int> bxcheck(4, 5, 0);
+
+            bx = bx.bit_xor(bx);
+
+            REQUIRE(bx == bxcheck);
+
+            for (auto& elem : bx)
+                REQUIRE(elem == 0);
+        }
+
+        SECTION("Non `BitXor` or `BitXorWith` type")
+        {
+            using namespace std::string_literals;
+
+            cortex::box<std::string> bx(0, 10, "hello"s);
+            cortex::box<std::wstring> nbx(4, 5, L"world"s);
+
+            /// To test, uncomment and code should not compile
+            // auto rbx { bx.bit_xor(nbx) };
+        }
+
+        SECTION("Scalar Xor")
+        {
+            cortex::box<int> bx(4, 5, 15);
+            cortex::box<int> bxcheck(4, 5, 9);
+
+            auto rbx { bx.bit_xor(6) };
+
+            REQUIRE(rbx == bxcheck);
+
+            for (auto& elem : rbx)
+                REQUIRE(elem == 9);
         }
     }
 }

--- a/src/test/modifiers.test.cpp
+++ b/src/test/modifiers.test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 #include <box.hpp>
+#include <functional>
 
 // Transpose, Flip, Rotate etc
 
@@ -169,6 +170,174 @@ TEST_CASE("Modifications")
             REQUIRE(rbx.columns() == 1);
 
             REQUIRE(rbx == bx);
+        }
+    }
+
+    SECTION("box::map")
+    {
+        SECTION("box::map - Lambda")
+        {
+            cortex::box<int> bx = { { 0, 1 }
+                                  , { 2, 3 }
+                                  , { 4, 5 }
+                                  , { 7, 6 }
+                                  , { 8, 9 } };
+
+            cortex::box<int> bxcheck = { { 0, 2 }
+                                       , { 4, 6 }
+                                       , { 8, 10 }
+                                       , { 12, 14 }
+                                       , { 16, 18 } };
+
+            REQUIRE(bx.size() == 10);
+            REQUIRE(bx.rows() == 5);
+            REQUIRE(bx.columns() == 2);
+
+            auto rbx { bx.map([](int i) { return i * 2; }) };
+
+            REQUIRE(bx.size() == 10);
+            REQUIRE(bx.rows() == 5);
+            REQUIRE(bx.columns() == 2);
+
+            REQUIRE(rbx.size() == 10);
+            REQUIRE(rbx.rows() == 5);
+        }
+
+        SECTION("box::map - Lambda - Empty")
+        {
+            cortex::box<int> bx;
+
+            REQUIRE(bx.empty());
+            REQUIRE(bx.size() == 0);
+            REQUIRE(bx.rows() == 0);
+            REQUIRE(bx.columns() == 0);
+
+            auto rbx { bx.map([](int i) { return i * 2; }) };
+
+            REQUIRE(rbx.empty());
+            REQUIRE(rbx.size() == 0);
+            REQUIRE(rbx.rows() == 0);
+            REQUIRE(rbx.columns() == 0);
+
+            REQUIRE(rbx == bx);
+        }
+
+        SECTION("box::map - Double Call - Intermidiate")
+        {
+            cortex::box<int> bx = { { 0, 1 }
+                                  , { 2, 3 }
+                                  , { 4, 5 }
+                                  , { 6, 7 }
+                                  , { 8, 9 } };
+
+            cortex::box<int> bxcheck = { { 0, 1 }
+                                       , { 2, 3 }
+                                       , { 4, 5 }
+                                       , { 6, 7 }
+                                       , { 8, 9 } };
+
+            cortex::box<int> ibxcheck = { { 0, 2 }
+                                        , { 4, 6 }
+                                        , { 8, 10 }
+                                        , { 12, 14 }
+                                        , { 16, 18 } };
+
+            cortex::box<int> rbxcheck = { { -3, -1 }
+                                        , { -7, -5 }
+                                        , { -11, -9 }
+                                        , { -15, -13 }
+                                        , { -19, -17 } };
+
+            REQUIRE(bx.size() == 10);
+            REQUIRE(bx.rows() == 5);
+            REQUIRE(bx.columns() == 2);
+
+            auto ibx { bx.map([](int i) { return i * 2; }) };
+
+            REQUIRE(bx == bxcheck);
+
+            REQUIRE(ibx.size() == 10);
+            REQUIRE(ibx.rows() == 5);
+            REQUIRE(ibx.columns() == 2);
+            REQUIRE(ibx == ibxcheck);
+
+            auto rbx { ibx.map([](int i) { return i ^ -3; }) };
+
+            REQUIRE(ibx == ibxcheck);
+
+            REQUIRE(rbx.size() == 10);
+            REQUIRE(rbx.rows() == 5);
+            REQUIRE(rbx.columns() == 2);
+            REQUIRE(rbx == rbxcheck);
+        }
+
+        SECTION("box::map - Double Call - Chained")
+        {
+            cortex::box<int> bx = { { 0, 1 }
+                                  , { 2, 3 }
+                                  , { 4, 5 }
+                                  , { 6, 7 }
+                                  , { 8, 9 } };
+
+            cortex::box<int> bxcheck = { { 0, 1 }
+                                       , { 2, 3 }
+                                       , { 4, 5 }
+                                       , { 6, 7 }
+                                       , { 8, 9 } };
+
+            cortex::box<int> rbxcheck = { { -3, -1 }
+                                        , { -7, -5 }
+                                        , { -11, -9 }
+                                        , { -15, -13 }
+                                        , { -19, -17 } };
+
+            REQUIRE(bx.size() == 10);
+            REQUIRE(bx.rows() == 5);
+            REQUIRE(bx.columns() == 2);
+
+            auto rbx { bx.map([](int i) { return i * 2; }).map([](int i) { return i ^ -3; }) };
+
+            REQUIRE(bx == bxcheck);
+
+            REQUIRE(rbx.size() == 10);
+            REQUIRE(rbx.rows() == 5);
+            REQUIRE(rbx.columns() == 2);
+            REQUIRE(rbx == rbxcheck);
+        }
+
+        /// note: Because the element type of the box
+        /// has to be known, using a l-value reference 
+        /// currently breaks the current type deduction 
+        /// implentation of `box::map`. Thus lambdas must 
+        /// have value semantics.
+        SECTION("box::map - Named Lambda")
+        {
+            cortex::box<int> bx = { { 0, 1 }
+                                  , { 2, 3 }
+                                  , { 4, 5 }
+                                  , { 6, 7 }
+                                  , { 8, 9 } };
+
+            auto square = [](const auto& i) { return i * i; };
+
+            cortex::box<int> bxcheck = { { 0, 1 }
+                                       , { 4, 9 }
+                                       , { 16, 25 }
+                                       , { 36, 49 }
+                                       , { 64, 81 } };
+
+            REQUIRE(bx.size() == 10);
+            REQUIRE(bx.rows() == 5);
+            REQUIRE(bx.columns() == 2);
+
+            auto rbx { bx.map(square) };
+
+            REQUIRE(bx.size() == 10);
+            REQUIRE(bx.rows() == 5);
+            REQUIRE(bx.columns() == 2);
+
+            REQUIRE(rbx.size() == 10);
+            REQUIRE(rbx.rows() == 5);
         }
     }
 }

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -154,4 +154,156 @@ TEST_CASE("Arithmatic Operators")
             }
         }
     }
+
+    SECTION("Minus and Minus Assign")
+    {
+        SECTION("Minus")
+        {
+            SECTION("Same Type")
+            {
+                cortex::box<int> a = { { 1, 2, 3 }
+                                     , { 4, 5, 6 } };
+
+                REQUIRE(a.size() == 6);
+                REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                cortex::box<int> b = { { 5, 113, 13 }
+                                     , { 243, -42, 114 } };
+
+                REQUIRE(b.size() == 6);
+                REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                auto c { a - b };
+
+                REQUIRE(c.size() == 6);
+                REQUIRE(c.dimensions() == std::tuple{2, 3});
+                REQUIRE(c == cortex::box<int> { { -4, -111, -10 }
+                                              , { -239, 47, -108 } });
+            }
+        
+
+            SECTION("Different Types")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<double> b = { { 6, 23 }
+                                            , { 4.5, 8.75 }
+                                            , { 1.15, 435 }
+                                            , { 13.4, 0.4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a - b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<double> { { -5.0, -21.0 }
+                                                     , { -1.5, -4.75 }
+                                                     , { 3.85, -429.0 }
+                                                     , { -6.4, 7.6 } });
+            }
+
+            SECTION("Self Minus")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a - a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0}
+                                                  , { 0, 0 } });
+            }
+        }
+
+        SECTION("Minus Assign")
+        {
+            SECTION("Same Type")
+            {
+                cortex::box<int> a = { { 1, 2, 3 }
+                                     , { 4, 5, 6 } };
+
+                REQUIRE(a.size() == 6);
+                REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                cortex::box<int> b = { { 25, 14, 2 }
+                                     , { -14, -2453, 12 } };
+
+                REQUIRE(b.size() == 6);
+                REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                a -= b;
+
+                REQUIRE(a.size() == 6);
+                REQUIRE(a.dimensions() == std::tuple{2, 3});
+                REQUIRE(a == cortex::box<int> { { -24, -12, 1 }
+                                              , { 18, 2458, -6 } });
+            }
+        
+
+            SECTION("Different Types")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<double> b = { { 6, 23 }
+                                            , { 4.5, 8.75 }
+                                            , { 1.15, 435 }
+                                            , { 13.5, 0.4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a -= b, std::invalid_argument);
+                    b -= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<double> { { 5.0, 21.0 }
+                                                     , { 1.5, 4.75 }
+                                                     , { -3.85, 429.0 }
+                                                     , { 6.5, -7.6 } });
+            }
+
+            SECTION("Self Minus")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    a -= a;
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+                    REQUIRE(a == cortex::box<int> { { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 } });
+            }
+        }
+    }
 }

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -486,6 +486,354 @@ TEST_CASE("Arithmatic Operators")
             }
         }
     }
+
+    SECTION("Divide and Divide Assign")
+    {
+        SECTION("Box Divide")
+        {
+            SECTION("Divide")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a / b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 0, 0 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 2 }
+                                           , { 1, 8 }
+                                           , { 1, 5 }
+                                           , { 2, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a / b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 0, 1 }
+                                                    , { 3, 0 }
+                                                    , { 5, 1 }
+                                                    , { 3, 2 } });
+                }
+
+                SECTION("Self Divide")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a / a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 1, 1 }
+                                                  , { 1, 1 }
+                                                  , { 1, 1 }
+                                                  , { 1, 1 } });
+                }
+            }
+
+            SECTION("Divide Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a /= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 0, 0 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a /= b, std::invalid_argument);
+                    b /= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 6, 11 }
+                                                  , { 15, 2 }
+                                                  , { 23, 42 }
+                                                  , { 1, 0 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Divide")
+        {
+            SECTION("Divide")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a / 5 };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 1, 1 } });
+                }
+            }
+
+            SECTION("Divide Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a /= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 1, 1 } });
+                }
+            }
+        }
+    }
+
+    SECTION("Modulo and Modulo Assign")
+    {
+        SECTION("Box Modulo")
+        {
+            SECTION("Modulo")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a % b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 1, 2, 3 }
+                                                  , { 4, 5, 6 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 23 }
+                                           , { 45, 8 }
+                                           , { 115, 255 }
+                                           , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a % b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 1, 2 }
+                                                    , { 3, 4 }
+                                                    , { 5, 6 }
+                                                    , { 7, 0 } });
+                }
+
+                SECTION("Self Modulo")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a % a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 } });
+                }
+            }
+
+            SECTION("Modulo Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a %= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 1, 2, 3 }
+                                                  , { 4, 5, 6 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a %= b, std::invalid_argument);
+                    b %= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 0, 1 }
+                                                  , { 0, 0 }
+                                                  , { 0, 3 }
+                                                  , { 6, 4 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Modulo")
+        {
+            SECTION("Modulo")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a % 5 };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 1, 2, 3 }
+                                                  , { 4, 0, 1 } });
+                }
+            }
+
+            SECTION("Modulo Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a %= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 1, 2, 3 }
+                                                  , { 4, 0, 1 } });
+                }
+            }
+        }
+    }
 }
 
 TEST_CASE("Bit Operators")

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -306,4 +306,50 @@ TEST_CASE("Arithmatic Operators")
             }
         }
     }
+
+}
+
+TEST_CASE("Bit Operators")
+{
+    SECTION("Bit Not")
+    {
+        cortex::box<int> a = { { 1, 2 }
+                             , { 3, 4 }
+                             , { 5, 6 }
+                             , { 7, 8 } };
+
+        REQUIRE(a.size() == 8);
+        REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+        auto b { ~a };
+
+        REQUIRE(b.size() == 8);
+        REQUIRE(b.dimensions() == std::tuple{4, 2});
+        REQUIRE(b == cortex::box<int> { { -2, -3 }
+                                      , { -4, -5 }
+                                      , { -6, -7 }
+                                      , { -8, -9 } });
+    }
+
+}
+
+TEST_CASE("Utility Operators")
+{
+    SECTION("Transpose")
+    {
+        cortex::box<int> a = { { 1, 2 }
+                             , { 3, 4 }
+                             , { 5, 6 }
+                             , { 7, 8 } };
+
+        REQUIRE(a.size() == 8);
+        REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+        auto b { !a };
+
+        REQUIRE(b.size() == 8);
+        REQUIRE(b.dimensions() == std::tuple{2, 4});
+        REQUIRE(b == cortex::box<int> { { 1, 3, 5, 7 }
+                                      , { 2, 4, 6, 8 } });
+    }
 }

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -1751,19 +1751,160 @@ TEST_CASE("Utility Operators")
 {
     SECTION("Transpose")
     {
-        cortex::box<int> a = { { 1, 2 }
-                             , { 3, 4 }
-                             , { 5, 6 }
-                             , { 7, 8 } };
+        SECTION("Transpose")
+        {
+            cortex::box<int> a = { { 1, 2 }
+                                , { 3, 4 }
+                                , { 5, 6 }
+                                , { 7, 8 } };
 
-        REQUIRE(a.size() == 8);
-        REQUIRE(a.dimensions() == std::tuple{4, 2});
+            REQUIRE(a.size() == 8);
+            REQUIRE(a.dimensions() == std::tuple{4, 2});
 
-        auto b { !a };
+            auto b { !a };
 
-        REQUIRE(b.size() == 8);
-        REQUIRE(b.dimensions() == std::tuple{2, 4});
-        REQUIRE(b == cortex::box<int> { { 1, 3, 5, 7 }
-                                      , { 2, 4, 6, 8 } });
+            REQUIRE(b.size() == 8);
+            REQUIRE(b.dimensions() == std::tuple{2, 4});
+            REQUIRE(b == cortex::box<int> { { 1, 3, 5, 7 }
+                                        , { 2, 4, 6, 8 } });
+        }
+
+        SECTION("Transpose Empty")
+        {
+            cortex::box<int> a;
+
+            REQUIRE(a.size() == 0);
+            REQUIRE(a.dimensions() == std::tuple{0, 0});
+
+            auto b { !a };
+
+            REQUIRE(b.size() == 0);
+            REQUIRE(b.dimensions() == std::tuple{0, 0});
+        }
+
+        SECTION("Transpose Single Element")
+        {
+            cortex::box<int> a = { { 1 } };
+
+            REQUIRE(a.size() == 1);
+            REQUIRE(a.dimensions() == std::tuple{1, 1});
+
+            auto b { !a };
+
+            REQUIRE(b.size() == 1);
+            REQUIRE(b.dimensions() == std::tuple{1, 1});
+            REQUIRE(b == cortex::box<int> { { 1 } });
+        }
+
+        SECTION("Transpose Assign")
+        {
+            cortex::box<int> a = { { 1, 2 }
+                                , { 3, 4 }
+                                , { 5, 6 }
+                                , { 7, 8 } };
+
+            REQUIRE(a.size() == 8);
+            REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+            a = !a;
+
+            REQUIRE(a.size() == 8);
+            REQUIRE(a.dimensions() == std::tuple{2, 4});
+            REQUIRE(a == cortex::box<int> { { 1, 3, 5, 7 }
+                                        , { 2, 4, 6, 8 } });
+        }
+    }
+
+    SECTION("Map")
+    {
+        SECTION("Map")
+        {
+            SECTION("Map - Lambda")
+            {
+                cortex::box<int> a = { { 1, 2 }
+                                     , { 3, 4 }
+                                     , { 5, 6 }
+                                     , { 7, 8 } };
+
+                REQUIRE(a.size() == 8);
+                REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                auto b { a || [](const auto& i) { return i * 2; } };
+
+                REQUIRE(b.size() == 8);
+                REQUIRE(b.dimensions() == std::tuple{4, 2});
+                REQUIRE(b == cortex::box<int> { { 2, 4 }
+                                              , { 6, 8 }
+                                              , { 10, 12 }
+                                              , { 14, 16 } });
+            }
+
+            SECTION("Map - Named Lambda")
+            {
+                cortex::box<int> a = { { 1, 2 }
+                                     , { 3, 4 }
+                                     , { 5, 6 }
+                                     , { 7, 8 } };
+
+                auto xor_3 = [](const auto& i) { return i ^ 3; };
+
+                REQUIRE(a.size() == 8);
+                REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                auto b { a || xor_3 };
+
+                REQUIRE(b.size() == 8);
+                REQUIRE(b.dimensions() == std::tuple{4, 2});
+                REQUIRE(b == cortex::box<int> { { 2, 1 }
+                                              , { 0, 7 }
+                                              , { 6, 5 }
+                                              , { 4, 11 } });
+            }
+
+            SECTION("Map - Chained Lambdas")
+            {
+                cortex::box<int> a = { { 1, 2 }
+                                     , { 3, 4 }
+                                     , { 5, 6 }
+                                     , { 7, 8 } };
+
+                REQUIRE(a.size() == 8);
+                REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                auto b { a || [](const auto& i) { return i * 2; } 
+                           || [](const auto& i) { return i ^ 3; } };
+
+                REQUIRE(b.size() == 8);
+                REQUIRE(b.dimensions() == std::tuple{4, 2});
+                REQUIRE(b == cortex::box<int> { { 1, 7 }
+                                              , { 5, 11 }
+                                              , { 9, 15 }
+                                              , { 13, 19 } });
+            }
+
+            SECTION("Map - Chained Named Lambdas")
+            {
+                cortex::box<int> a = { { 1, 2 }
+                                     , { 3, 4 }
+                                     , { 5, 6 }
+                                     , { 7, 8 } };
+
+                auto square = [](const auto& i) { return i * 2; };
+                auto xor_3 = [](const auto& i) { return i ^ 3; };
+
+                REQUIRE(a.size() == 8);
+                REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                auto b { a || square 
+                           || xor_3 };
+
+                REQUIRE(b.size() == 8);
+                REQUIRE(b.dimensions() == std::tuple{4, 2});
+                REQUIRE(b == cortex::box<int> { { 1, 7 }
+                                              , { 5, 11 }
+                                              , { 9, 15 }
+                                              , { 13, 19 } });
+            }
+        }
     }
 }

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -307,6 +307,185 @@ TEST_CASE("Arithmatic Operators")
         }
     }
 
+    SECTION("Multiply and Multiply Assign")
+    {
+        SECTION("Box Multiply")
+        {
+            SECTION("Multiply")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a * b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 5, 226, 39 }
+                                                  , { 972, -210, 684 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<double> b = { { 6, 23 }
+                                            , { 4.5, 8.75 }
+                                            , { 1.15, 435 }
+                                            , { 13.4, 0.4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a * b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<double> { { 6, 46 }
+                                                     , { 13.5, 35 }
+                                                     , { 5.75, 2610 }
+                                                     , { 93.8, 3.2 } });
+                }
+
+                SECTION("Self Multiply")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a * a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 1, 4 }
+                                                  , { 9, 16 }
+                                                  , { 25, 36 }
+                                                  , { 49, 64 } });
+                }
+            }
+
+            SECTION("Multiply Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a *= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 5, 226, 39 }
+                                                  , { 972, -210, 684 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<double> b = { { 6, 23 }
+                                            , { 4.5, 8.75 }
+                                            , { 1.15, 435 }
+                                            , { 13.4, 0.4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a *= b, std::invalid_argument);
+                    b *= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<double> { { 6, 46 }
+                                                     , { 13.5, 35 }
+                                                     , { 5.75, 2610 }
+                                                     , { 93.8, 3.2 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Multiply")
+        {
+            SECTION("Multiply")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a * 5 };
+                    auto c { 4 * a };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 5, 10, 15 }
+                                                  , { 20, 25, 30 } });
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 4, 8, 12 }
+                                                  , { 16, 20, 24 } });
+                }
+            }
+
+            SECTION("Multiply Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a *= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 5, 10, 15 }
+                                                  , { 20, 25, 30 } });
+                }
+            }
+        }
+    }            
 }
 
 TEST_CASE("Bit Operators")

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -485,11 +485,551 @@ TEST_CASE("Arithmatic Operators")
                 }
             }
         }
-    }            
+    }
 }
 
 TEST_CASE("Bit Operators")
 {
+    SECTION("Bit And and Bit And Assign")
+    {
+        SECTION("Box Bit And")
+        {
+            SECTION("Bit And")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a & b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 1, 0, 1 }
+                                                  , { 0, 4, 2 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 23 }
+                                           , { 45, 8 }
+                                           , { 115, 255 }
+                                           , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a & b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 0, 2 }
+                                                    , { 1, 0 }
+                                                    , { 1, 6 }
+                                                    , { 5, 0 } });
+                }
+
+                SECTION("Self Bit And")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a & a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 1, 2 }
+                                                  , { 3, 4 }
+                                                  , { 5, 6 }
+                                                  , { 7, 8 } });
+                }
+            }
+
+            SECTION("Bit And Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a &= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 1, 0, 1 }
+                                                  , { 0, 4, 2 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a &= b, std::invalid_argument);
+                    b &= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 0, 2 }
+                                                  , { 1, 0 }
+                                                  , { 1, 6 }
+                                                  , { 5, 0 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Bit And")
+        {
+            SECTION("Bit And")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a & 5 };
+                    auto c { 4 & a };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 1, 0, 1 }
+                                                  , { 4, 5, 4 } });
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 4, 4, 4 } });
+                }
+            }
+
+            SECTION("Bit And Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a &= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 1, 0, 1 }
+                                                  , { 4, 5, 4 } });
+                }
+            }
+        }
+    }
+
+    SECTION("Bit Or and Bit Or Assign")
+    {
+        SECTION("Box Bit Or")
+        {
+            SECTION("Bit Or")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a | b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 5, 115, 15 }
+                                                  , { 247, -41, 118 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 23 }
+                                           , { 45, 8 }
+                                           , { 115, 255 }
+                                           , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a | b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 7, 23 }
+                                                    , { 47, 12 }
+                                                    , { 119, 255 }
+                                                    , { 15, 12 } });
+                }
+
+                SECTION("Self Bit Or")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a | a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 1, 2 }
+                                                  , { 3, 4 }
+                                                  , { 5, 6 }
+                                                  , { 7, 8 } });
+                }
+            }
+
+            SECTION("Bit Or Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a |= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 5, 115, 15 }
+                                                  , { 247, -41, 118 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a |= b, std::invalid_argument);
+                    b |= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 7, 23 }
+                                                  , { 47, 12 }
+                                                  , { 119, 255 }
+                                                  , { 15, 12 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Bit Or")
+        {
+            SECTION("Bit Or")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a | 5 };
+                    auto c { 4 | a };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 5, 7, 7 }
+                                                  , { 5, 5, 7 } });
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 5, 6, 7 }
+                                                  , { 4, 5, 6 } });
+                }
+            }
+
+            SECTION("Bit Or Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a |= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 5, 7, 7 }
+                                                  , { 5, 5, 7 } });
+                }
+            }
+        }
+    }
+
+    SECTION("Bit Xor and Bit Xor Assign")
+    {
+        SECTION("Box Bit Xor")
+        {
+            SECTION("Bit Xor")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a ^ b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 4, 115, 14 }
+                                                  , { 247, -45, 116 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 23 }
+                                           , { 45, 8 }
+                                           , { 115, 255 }
+                                           , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a ^ b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 7, 21 }
+                                                    , { 46, 12 }
+                                                    , { 118, 249 }
+                                                    , { 10, 12 } });
+                }
+
+                SECTION("Self Bit Xor")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a ^ a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 } });
+                }
+            }
+
+            SECTION("Bit Xor Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a ^= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 4, 115, 14 }
+                                                  , { 247, -45, 116 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a ^= b, std::invalid_argument);
+                    b ^= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 7, 21 }
+                                                  , { 46, 12 }
+                                                  , { 118, 249 }
+                                                  , { 10, 12 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Bit Xor")
+        {
+            SECTION("Bit Xor")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a ^ 5 };
+                    auto c { 4 ^ a };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 4, 7, 6 }
+                                                  , { 1, 0, 3 } });
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 5, 6, 7 }
+                                                  , { 0, 1, 2 } });
+                }
+            }
+
+            SECTION("Bit Xor Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a ^= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 4, 7, 6 }
+                                                  , { 1, 0, 3 } });
+                }
+            }
+        }
+    }
+
     SECTION("Bit Not")
     {
         cortex::box<int> a = { { 1, 2 }
@@ -509,7 +1049,6 @@ TEST_CASE("Bit Operators")
                                       , { -6, -7 }
                                       , { -8, -9 } });
     }
-
 }
 
 TEST_CASE("Utility Operators")

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -1030,6 +1030,354 @@ TEST_CASE("Bit Operators")
         }
     }
 
+    SECTION("Left Bit Shift and Left Bit Shift Assign")
+    {
+        SECTION("Box Left Bit Shift")
+        {
+            SECTION("Left Bit Shift")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a << b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 32, 262144, 24576 }
+                                                  , { 2097152, 20971520, 1572864 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 2 }
+                                           , { 1, 8 }
+                                           , { 1, 5 }
+                                           , { 2, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a << b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 64, 8 }
+                                                    , { 6, 1024 }
+                                                    , { 10, 192 }
+                                                    , { 28, 128 } });
+                }
+
+                SECTION("Self Left Bit Shift")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a << a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 2, 8 }
+                                                  , { 24, 64 }
+                                                  , { 160, 384 }
+                                                  , { 896, 2048 } });
+                }
+            }
+
+            SECTION("Left Bit Shift Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a <<= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 32, 262144, 24576 }
+                                                  , { 2097152, 20971520, 1572864 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a <<= b, std::invalid_argument);
+                    b <<= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 12, 92 }
+                                                  , { 360, 128 }
+                                                  , { 3680, 16320 }
+                                                  , { 1664, 1024 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Left Bit Shift")
+        {
+            SECTION("Left Bit Shift")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a << 5 };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 32, 64, 96 }
+                                                  , { 128, 160, 192 } });
+                }
+            }
+
+            SECTION("Left Bit Shift Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a <<= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 32, 64, 96 }
+                                                  , { 128, 160, 192 } });
+                }
+            }
+        }
+    }
+
+    SECTION("Right Bit Shift and Right Bit Shift Assign")
+    {
+        SECTION("Box Right Bit Shift")
+        {
+            SECTION("Right Bit Shift")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    auto c { a >> b };
+
+                    REQUIRE(c.size() == 6);
+                    REQUIRE(c.dimensions() == std::tuple{2, 3});
+                    REQUIRE(c == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 0, 0 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<short> b = { { 6, 23 }
+                                           , { 45, 8 }
+                                           , { 115, 255 }
+                                           , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a >> b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<short> { { 0, 0 }
+                                                    , { 0, 0 }
+                                                    , { 0, 0 }
+                                                    , { 0, 0 } });
+                }
+
+                SECTION("Self Right Bit Shift")
+                {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a >> a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 }
+                                                  , { 0, 0 } });
+                }
+            }
+
+            SECTION("Right Bit Shift Assign") 
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    cortex::box<int> b = { { 5, 113, 13 }
+                                         , { 243, -42, 114 } };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                    a >>= b;
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 0, 0 } });
+                }
+
+                SECTION("Different Type")
+                {
+                    cortex::box<short> a = { { 1, 2 }
+                                           , { 3, 4 }
+                                           , { 5, 6 }
+                                           , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<int> b = { { 6, 23 }
+                                         , { 45, 8 }
+                                         , { 115, 255 }
+                                         , { 13, 4 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a >>= b, std::invalid_argument);
+                    b >>= a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<int> { { 3, 5 }
+                                                  , { 5, 0 }
+                                                  , { 3, 3 }
+                                                  , { 0, 0 } });
+                }
+            }
+        }
+
+        SECTION("Scalar Right Bit Shift")
+        {
+            SECTION("Right Bit Shift")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    auto b { a >> 5 };
+
+                    REQUIRE(b.size() == 6);
+                    REQUIRE(b.dimensions() == std::tuple{2, 3});
+                    REQUIRE(b == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 0, 0 } });
+                }
+            }
+
+            SECTION("Right Bit Shift Assign")
+            {
+                SECTION("Same Type")
+                {
+                    cortex::box<int> a = { { 1, 2, 3 }
+                                         , { 4, 5, 6 } };
+
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                    a >>= 5;
+                    
+                    REQUIRE(a.size() == 6);
+                    REQUIRE(a.dimensions() == std::tuple{2, 3});
+                    REQUIRE(a == cortex::box<int> { { 0, 0, 0 }
+                                                  , { 0, 0, 0 } });
+                }
+            }
+        }
+    }
+
     SECTION("Bit Not")
     {
         cortex::box<int> a = { { 1, 2 }

--- a/src/test/operators.test.cpp
+++ b/src/test/operators.test.cpp
@@ -1,2 +1,157 @@
 #include <catch2/catch.hpp>
 #include <box.hpp>
+
+TEST_CASE("Arithmatic Operators")
+{
+    SECTION("Add and Add Assign")
+    {
+        SECTION("Add")
+        {
+            SECTION("Same Type")
+            {
+                cortex::box<int> a = { { 1, 2, 3 }
+                                     , { 4, 5, 6 } };
+
+                REQUIRE(a.size() == 6);
+                REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                cortex::box<int> b = { { 7, 8, 9 }
+                                     , { 10, 11, 12 } };
+
+                REQUIRE(b.size() == 6);
+                REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                auto c { a + b };
+
+                REQUIRE(c.size() == 6);
+                REQUIRE(c.dimensions() == std::tuple{2, 3});
+                REQUIRE(c == cortex::box<int> { { 8, 10, 12 }
+                                              , { 14, 16, 18 } });
+            }
+        
+
+            SECTION("Different Types")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<double> b = { { 6, 23 }
+                                            , { 4.52, 8.75 }
+                                            , { 1.12, 435 }
+                                            , { 13.4221, 0.4234 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    auto c { a + b };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<double> { { 7.0, 25.0 }
+                                                     , { 7.52, 12.75 }
+                                                     , { 6.12, 441.0 }
+                                                     , { 20.4221, 8.4234 } });
+            }
+
+            SECTION("Self Add")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    auto c { a + a };
+
+                    REQUIRE(c.size() == 8);
+                    REQUIRE(c.dimensions() == std::tuple{4, 2});
+                    REQUIRE(c == cortex::box<int> { { 2, 4 }
+                                                  , { 6, 8 }
+                                                  , { 10, 12 }
+                                                  , { 14, 16 } });
+            }
+        }
+
+        SECTION("Add Assign")
+        {
+            SECTION("Same Type")
+            {
+                cortex::box<int> a = { { 1, 2, 3 }
+                                     , { 4, 5, 6 } };
+
+                REQUIRE(a.size() == 6);
+                REQUIRE(a.dimensions() == std::tuple{2, 3});
+
+                cortex::box<int> b = { { 7, 8, 9 }
+                                     , { 10, 11, 12 } };
+
+                REQUIRE(b.size() == 6);
+                REQUIRE(b.dimensions() == std::tuple{2, 3});
+
+                a += b;
+
+                REQUIRE(a.size() == 6);
+                REQUIRE(a.dimensions() == std::tuple{2, 3});
+                REQUIRE(a == cortex::box<int> { { 8, 10, 12 }
+                                              , { 14, 16, 18 } });
+            }
+        
+
+            SECTION("Different Types")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    cortex::box<double> b = { { 6, 23 }
+                                            , { 4.52, 8.75 }
+                                            , { 1.12, 435 }
+                                            , { 13.4221, 0.4234 } };
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+
+                    REQUIRE_THROWS_AS(a += b, std::invalid_argument);
+                    b += a;
+
+                    REQUIRE(b.size() == 8);
+                    REQUIRE(b.dimensions() == std::tuple{4, 2});
+                    REQUIRE(b == cortex::box<double> { { 7.0, 25.0 }
+                                                     , { 7.52, 12.75 }
+                                                     , { 6.12, 441.0 }
+                                                     , { 20.4221, 8.4234 } });
+            }
+
+            SECTION("Self Add")
+            {
+                    cortex::box<int> a = { { 1, 2 }
+                                         , { 3, 4 }
+                                         , { 5, 6 }
+                                         , { 7, 8 } };
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+
+                    a += a;
+
+                    REQUIRE(a.size() == 8);
+                    REQUIRE(a.dimensions() == std::tuple{4, 2});
+                    REQUIRE(a == cortex::box<int> { { 2, 4 }
+                                                  , { 6, 8 }
+                                                  , { 10, 12 }
+                                                  , { 14, 16 } });
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Release Notes

## Added:

### Element-wise Operations:
Performs element-wise _operation_ between two boxes or a box and a scalar.
  - `box::mod`
  - `box::bit_and`
  - `box::bit_or`
  - `box::bit_xor`
  - `box::bit_not`
  - `box::shift_left`
  - `box::shift_right`

### Operator Overloads:
Overloads on the arithmetic and bitwise operators corresponding to the arithmetic and bitwise methods on boxes. Includes assigning versions of the operators. 
 - [ +, += ] ................ Calls `box::add`.
 - [ -, -= ] ................... Calls `box::sub`.
 - [ *, *= ] ................... Calls `box::mul`.
 - [ /, /= ] ................... Calls `box::div`.
 - [ %, %= ] ............... Calls `box::mod`.
 - [ &, &= ] ............... Calls `box::bit_and`
 - [ |, |= ] .................... Calls `box::bit_or`.
 - [ ^, ^= ] ................ Calls `box::bit_xor`.
 - [ ~ ] ......................... Calls `box::bit_not`.
 - [ <<, <<= ] .......... Calls `box::shift_left`.
 - [ >>, >>= ] .......... Calls `box::shift_right`.

### Map
Class method and operator overload for mapping a function over a box. Plans are in place to add more variations of `box::map`.
- `box::map` - Takes a unary lambda and maps it over the box. Can be chained.
- [ || ] - Maps a unary function over a box. Can be chained. Calls `box::map`.

### Transpose
Added operator overload for transpose operator.
 - [ ! ] - Transposes a box. Calls `box::transpose`.

## Changes:
- Loosed requirements on arithmetic and bitwise methods to accept any type that satisfy the concept of `Any`. This is not as rigorous and a solution to restrict the type down again will be released soon.

## Dependency Changes:
- cortex-concepts :: 0.1.1 -> 0.2.1
- Added header `<functional>`