### PR TITLE
Box v0.7.0 Release

### DIFF
--- a/package.json5
+++ b/package.json5
@@ -1,6 +1,6 @@
 {
     name: 'cortex-box',
-    version: '0.6.0',
+    version: '0.7.0',
     namespace: 'cortex',
     test_driver: 'Catch-Main',
     depends: [

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -373,9 +373,9 @@ namespace cortex
         /// @brief Intialiser List Assign
         ///
         /// @details Uses std::initializer_list to reassign 
-        /// values to a box. The box's memory is released and
-        /// new memory is allocated. This also resizes the box's
-        /// dimensions.
+        /// values to a box. If the lists dimensions are not
+        /// the same as the box's dimensions, then the box
+        /// is resized to match the dimensions of the list.
         /// 
         /// @param list type: [std::initializer_list<std::initializer_list<value_type>>]
         constexpr void assign(std::initializer_list<std::initializer_list<value_type>> list)

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -3,7 +3,7 @@
 /// @file box
 /// @author Tyler Swann (oraqlle@github.com)
 /// @brief Two Dimensional Access To Contiguous Data
-/// @version 2.2.0
+/// @version 2.3.0
 /// @date 12-06-2022
 ///
 /// @copyright Copyright (c) 2022
@@ -37,14 +37,10 @@ namespace cortex
     /// stores elements sequentially in memory but is
     /// viewed as a series of rows and columns.
     ///
-    /// @todo Add support for iterator constructors -------------------------- ✔️
-    /// @todo Add other modification methods (mod, xor etc.) ----------------- ✔️
-    /// @todo Add flips ------------------------------------------------------ ✔️
-    /// @todo Add support for operator overloads ----------------------------- ✔️
-    /// @todo Projection method ---------------------------------------------- 🗑️ (do-able with assign)
-    /// @todo Add support for single initialiser constructor ----------------- 🗑️ (too ambiguous for compiler)
-    /// @todo Add support for assign -----------------------------------------
-    /// @todo Add rotates ----------------------------------------------------
+    /// @todo Add additional box::map methods -------------------------------- 
+    /// @todo Added support for slice operator ------------------------------- 
+    /// @todo Finish docs ---------------------------------------------------- 
+    /// @todo Update test cases to support current version of box ------------  
     ///
     /// @tparam _Tp
     template <typename _Tp, typename _Alloc = std::allocator<_Tp>>
@@ -327,7 +323,7 @@ namespace cortex
         /// from an initializer list of initializer lists. Elements
         /// ownership is moved to the box's memory.
         ///
-        /// @param list type: [std::initializer_list<std::initializer_list<value_type>>] | qualifiers: [const], [ref]
+        /// @param list type: [std::initializer_list<std::initializer_list<value_type>>]
         /// @return constexpr box&
         constexpr box& operator= (std::initializer_list<std::initializer_list<value_type>> list)
         {
@@ -372,6 +368,47 @@ namespace cortex
             m_finish = pointer();
             m_allocator = allocator_type();
         }
+
+
+        /// @brief Intialiser List Assign
+        ///
+        /// @details Uses std::initializer_list to reassign 
+        /// values to a box. The box's memory is released and
+        /// new memory is allocated. This also resizes the box's
+        /// dimensions.
+        /// 
+        /// @param list type: [std::initializer_list<std::initializer_list<value_type>>]
+        constexpr void assign(std::initializer_list<std::initializer_list<value_type>> list)
+        {
+            auto new_rows { list.size() };
+            auto new_columns { list.begin()->size() };
+
+            std::ranges::destroy(*this);
+
+            if (new_rows != m_rows || new_columns != m_columns)
+            {
+                if (m_start)
+                    _M_deallocate(m_start, _M_size(m_rows, m_columns));
+            
+                m_start = _M_allocate(_M_size(new_rows, new_columns));
+                m_finish = m_start + _M_size(new_rows, new_columns);
+            }
+            
+            m_rows = new_rows;
+            m_columns = new_columns;
+
+            using init_iter = typename decltype(list)::iterator;
+            auto offset{ 0uL };
+            for (init_iter row{ list.begin() }; row != list.end(); ++row)
+            {
+                if (row->size() != this->m_columns)
+                    throw std::invalid_argument("Columns must be all the same size");
+
+                std::uninitialized_move_n(row->begin(), this->m_columns, m_start + offset);
+                offset += this->m_columns;
+            }
+        }
+
 
         /// @brief Resizes the box to dimensions new_rows x new_columns.
         ///

--- a/src/test/constructors.test.cpp
+++ b/src/test/constructors.test.cpp
@@ -219,3 +219,106 @@ TEST_CASE("Constructors and Assignment")
         }
     }
 }
+
+TEST_CASE("Assignment")
+{
+    SECTION("box::assign - initialiser list")
+    {
+        SECTION("Same Size")
+        {
+            cortex::box<int> bx(3, 3, 1);
+
+            auto ptr { bx.data() };
+
+            REQUIRE(bx.size() == 9);
+            REQUIRE(bx.dimensions() == std::tuple{3, 3});
+            REQUIRE(bx.data() == ptr);
+            REQUIRE(bx == cortex::box<int> { { 1, 1, 1 }
+                                           , { 1, 1, 1 }
+                                           , { 1, 1, 1 } });
+
+            bx.assign({ { 1, 2, 3 }
+                      , { 4, 5, 6 }
+                      , { 7, 8, 9 } });
+            
+            REQUIRE(bx.size() == 9);
+            REQUIRE(bx.dimensions() == std::tuple{3, 3});
+            REQUIRE(bx.data() == ptr);
+            REQUIRE(bx == cortex::box<int> { { 1, 2, 3 }
+                                           , { 4, 5, 6 }
+                                           , { 7, 8, 9 } });
+        }
+
+        SECTION("Larger Size")
+        {
+            cortex::box<int> bx(3, 3, 1);
+
+            auto ptr { bx.data() };
+
+            REQUIRE(bx.size() == 9);
+            REQUIRE(bx.dimensions() == std::tuple{3, 3});
+            REQUIRE(ptr == bx.data());
+            REQUIRE(bx == cortex::box<int> { { 1, 1, 1 }
+                                           , { 1, 1, 1 }
+                                           , { 1, 1, 1 } });
+
+
+            bx.assign({ { 1, 2, 3 }
+                      , { 4, 5, 6 }
+                      , { 7, 8, 9 }
+                      , { 10, 11, 12 } });
+            
+            REQUIRE(bx.size() == 12);
+            REQUIRE(bx.dimensions() == std::tuple{4, 3});
+            REQUIRE(bx.data() != ptr);
+            REQUIRE(bx == cortex::box<int> { { 1, 2, 3 }
+                                           , { 4, 5, 6 }
+                                           , { 7, 8, 9 }
+                                           , { 10, 11, 12 } });
+        }
+
+        SECTION("Smaller Box")
+        {
+            cortex::box<int> bx(3, 3, 1);
+
+            auto ptr { bx.data() };
+
+            REQUIRE(bx.size() == 9);
+            REQUIRE(bx.dimensions() == std::tuple{3, 3});
+            REQUIRE(bx.data() == ptr);
+            REQUIRE(bx == cortex::box<int> { { 1, 1, 1 }
+                                           , { 1, 1, 1 }
+                                           , { 1, 1, 1 } });
+
+            bx.assign({ { 1, 2, 3, 4 } });
+
+            REQUIRE(bx.size() == 4);
+            REQUIRE(bx.dimensions() == std::tuple{1, 4});
+            REQUIRE(bx.data() != ptr);
+            REQUIRE(bx == cortex::box<int> { { 1, 2, 3, 4 } });
+        }
+
+        SECTION("Empty Box")
+        {
+            cortex::box<int> bx;
+
+            auto ptr { bx.data() };
+
+            REQUIRE(bx.size() == 0);
+            REQUIRE(bx.dimensions() == std::tuple{0, 0});
+            REQUIRE(ptr == bx.data());
+            REQUIRE(bx == cortex::box<int> { });
+
+            bx.assign({ { 1, 2, 3 }
+                      , { 4, 5, 6 }
+                      , { 7, 8, 9 } });
+            
+            REQUIRE(bx.size() == 9);
+            REQUIRE(bx.dimensions() == std::tuple{3, 3});
+            REQUIRE(bx.data() != ptr);
+            REQUIRE(bx == cortex::box<int> { { 1, 2, 3 }
+                                           , { 4, 5, 6 }
+                                           , { 7, 8, 9 } });
+        }
+    }
+}

--- a/src/test/iterators.test.cpp
+++ b/src/test/iterators.test.cpp
@@ -1,6 +1,5 @@
 #include <catch2/catch.hpp>
 #include <box.hpp>
-#include <iostream>
 
 TEST_CASE("Iterators")
 {


### PR DESCRIPTION
# Release Notes

## Added:
- `box::assign` - You can now use and initialiser list to reassign values in the box. May not allocate if the initialiser list has the same dimensions as the box but will reallocate otherwise, invalidating any iterators.

## Changes:
- Cleaned up @todo list