### PR TITLE
Box v0.9.0 Release

### DIFF
--- a/package.json5
+++ b/package.json5
@@ -1,6 +1,6 @@
 {
     name: 'cortex-box',
-    version: '0.8.0',
+    version: '0.9.0',
     namespace: 'cortex',
     test_driver: 'Catch-Main',
     depends: [

--- a/src/box.hpp
+++ b/src/box.hpp
@@ -21,8 +21,8 @@
 #include <memory>
 #include <utility>
 #include <initializer_list>
-#include <cassert>
 #include <ranges>
+#include <span>
 #include <vector>
 #include <execution>
 #include <functional>
@@ -694,19 +694,45 @@ namespace cortex
             return _M_data_ptr(m_start);
         }
 
-        /// @brief Subscript Operator.
+
+        /// @brief Slice
         ///
-        /// @details Returns a reference to the element that
-        /// is at the position indicated by the pointer
-        /// m_data + step. Offers linear access to the box's
-        /// elements.
+        /// @details Returns a slice of the box. The slice is
+        /// std::span over the indicated row of the box. The 
+        /// span is a view over the underlying data.
         ///
-        /// @param step type: [size_type]
-        /// @return constexpr reference
-        constexpr reference operator[](size_type step)
+        /// @exception std::out_of_range - if the row index is 
+        /// out of range of the box, the exception is thrown.
+        /// 
+        /// @param ridx type: [size_type]
+        /// @return std::span<value_type> 
+        constexpr auto
+        slice(size_type ridx)
+            -> std::span<value_type>
         {
-            return *(m_start + step);
+            if (ridx >= m_rows)
+                throw std::out_of_range("box::slice - row index out of range");
+            
+            return std::span<value_type>{
+                _M_data_ptr(m_start) + ridx * m_columns,
+                m_columns
+            };
         }
+
+
+        /// @brief Slice Operator
+        ///
+        /// @details Returns a slice of the box. The slice is
+        /// std::span over the indicated row of the box. The
+        /// span is a view over the underlying data. Calls
+        /// `box::slice`.
+        /// 
+        /// @param ridx 
+        /// @return std::span<value_type> 
+        constexpr auto 
+        operator[](size_type ridx)
+            -> std::span<value_type>
+        { return slice(ridx); }
 
         /// @brief Two Dimensional Element Access (Point Access).
         ///

--- a/src/test/constructors.test.cpp
+++ b/src/test/constructors.test.cpp
@@ -39,19 +39,19 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(nbx.rows() == 4);
             REQUIRE(nbx.columns() == 5);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-            {
-                REQUIRE(nbx[i] == 1);
-                REQUIRE(bx[i] == 1);
-            }
+            for (auto& v : bx)
+                REQUIRE(v == 1);
+
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
 
         SECTION("Move constructor")
         {
             cortex::box<int> bx(4, 5, 1);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == 1);
+            for (auto& v : bx)
+                REQUIRE(v == 1);
 
             cortex::box<int> nbx(std::move(bx));
 
@@ -59,8 +59,8 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(nbx.rows() == 4);
             REQUIRE(nbx.columns() == 5);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(nbx[i] == 1);
+            for (auto& v : bx)
+                REQUIRE(v == 1);
         }
 
         SECTION("Initializer List Constructor")
@@ -75,8 +75,8 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(bx.columns() == 2);
             REQUIRE(bx.size() == 10);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == static_cast<int>(i + 1));
+            for (auto i { 1 }; auto& v : bx)
+                REQUIRE(v == i++);
         }
 
         SECTION("Assign Constructor")
@@ -136,11 +136,11 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(nbx.columns() == 5);
             REQUIRE(bx.get_allocator() == alloc);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-            {
-                REQUIRE(nbx[i] == 1);
-                REQUIRE(bx[i] == 1);
-            }
+            for (auto& v : bx)
+                REQUIRE(v == 1);
+
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
 
         SECTION("Move constructor")
@@ -148,8 +148,8 @@ TEST_CASE("Constructors and Assignment")
             std::allocator<int> alloc;
             cortex::box<int> bx(4, 5, 1, alloc);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == 1);
+            for (auto& v : bx)
+                REQUIRE(v == 1);
 
             cortex::box<int> nbx(std::move(bx));
 
@@ -158,8 +158,8 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(nbx.columns() == 5);
             REQUIRE(nbx.get_allocator() == alloc);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(nbx[i] == 1);
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
     }
 
@@ -179,11 +179,11 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(nbx.rows() == 4);
             REQUIRE(nbx.columns() == 5);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-            {
-                REQUIRE(nbx[i] == 1);
-                REQUIRE(bx[i] == 1);
-            }
+            for (auto& v : bx)
+                REQUIRE(v == 1);
+            
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
 
         SECTION("Move assignment")
@@ -200,8 +200,8 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(nbx.rows() == 4);
             REQUIRE(nbx.columns() == 5);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(nbx[i] == 1);
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
 
         SECTION("Initializer List Assignment")
@@ -214,8 +214,8 @@ TEST_CASE("Constructors and Assignment")
             REQUIRE(bx.columns() == 3);
             REQUIRE(bx.size() == 9);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == static_cast<int>(i + 1));
+            for (auto i { 1 }; auto& v : bx)
+                REQUIRE(v == i++);
         }
     }
 }

--- a/src/test/element_access.test.cpp
+++ b/src/test/element_access.test.cpp
@@ -43,13 +43,38 @@ TEST_CASE("Element Access")
             REQUIRE_THROWS_AS(bx.at(10, 1), std::out_of_range);
         }
 
+        SECTION("box::slice")
+        {
+            cortex::box<int> bx { { 1, 2, 3 }
+                                , { 4, 5, 6 }
+                                , { 7, 8, 9 } };
+
+            auto slc { bx.slice(2) };
+            REQUIRE(slc.size() == 3);
+            REQUIRE(slc[0] == 7);
+            REQUIRE(slc[1] == 8);
+            REQUIRE(slc[2] == 9);
+            REQUIRE(slc.data() == bx.data() + 2 * bx.columns());
+
+            REQUIRE_THROWS_AS(bx.slice(10), std::out_of_range);
+        }
+
         SECTION("box::operator[]")
         {
-            cortex::box<int> bx(4, 5, 1);
-            REQUIRE(bx[0] == 1);
+            cortex::box<int> bx { { 1, 2, 3 }
+                                , { 4, 5, 6 }
+                                , { 7, 8, 9 } };
 
-            bx[0] = 2;
-            REQUIRE(bx[0] == 2);
+            auto slc { bx[2] };
+            REQUIRE(slc.size() == 3);
+            REQUIRE(slc[0] == 7);
+            REQUIRE(slc[1] == 8);
+            REQUIRE(slc[2] == 9);
+            REQUIRE(slc.data() == bx.data() + 2 * bx.columns());
+
+            REQUIRE(bx[1][1] == 5);
+
+            REQUIRE_THROWS_AS(bx[10], std::out_of_range);
         }
 
         SECTION("box::operator()")

--- a/src/test/masks.test.cpp
+++ b/src/test/masks.test.cpp
@@ -40,14 +40,12 @@ TEST_CASE("Boolean Masks")
         SECTION("Mismatched")
         {
             std::vector<int> v { 1, 2, 1, 1, 1, 5, 2, 5, 2, 2 };
-            cortex::box<int> bx(5, 2);
-            cortex::box<bool> bxcheck(5, 2);
-
-            for (auto i { 0ul }; i < v.size(); ++i)
-            {
-                bx[i] = v[i];
-                bxcheck[i] = v[i] == 2;
-            }
+            cortex::box<int> bx(v.begin(), v.end(), 5, 2);
+            cortex::box<bool> bxcheck { { false, true }
+                                      , { false, false }
+                                      , { false, false }
+                                      , { true, false }
+                                      , { true, true } };
 
             auto rbx { bx == 2 };
 
@@ -92,14 +90,12 @@ TEST_CASE("Boolean Masks")
         SECTION("Mismatched")
         {
             std::vector<int> v { 1, 2, 1, 1, 1, 5, 2, 5, 2, 2 };
-            cortex::box<int> bx(5, 2);
-            cortex::box<bool> bxcheck(5, 2);
-
-            for (auto i { 0ul }; i < v.size(); ++i)
-            {
-                bx[i] = v[i];
-                bxcheck[i] = v[i] != 2;
-            }
+            cortex::box<int> bx(v.begin(), v.end(), 5, 2);
+            cortex::box<bool> bxcheck { { true, false }
+                                      , { true, true }
+                                      , { true, true }
+                                      , { false, true }
+                                      , { false, false } };
 
             auto rbx { bx != 2 };
 
@@ -144,14 +140,12 @@ TEST_CASE("Boolean Masks")
         SECTION("Mismatched")
         {
             std::vector<int> v { 1, 2, 1, 1, 1, 5, 2, 5, 2, 2 };
-            cortex::box<int> bx(5, 2);
-            cortex::box<bool> bxcheck(5, 2);
-
-            for (auto i { 0ul }; i < v.size(); ++i)
-            {
-                bx[i] = v[i];
-                bxcheck[i] = v[i] < 2;
-            }
+            cortex::box<int> bx(v.begin(), v.end(), 5, 2);
+            cortex::box<bool> bxcheck { { true, false }
+                                      , { true, true }
+                                      , { true, false }
+                                      , { false, false }
+                                      , { false, false } };
 
             auto rbx { bx < 2 };
 
@@ -196,14 +190,12 @@ TEST_CASE("Boolean Masks")
         SECTION("Mismatched")
         {
             std::vector<int> v { 1, 2, 1, 1, 1, 5, 2, 5, 2, 2 };
-            cortex::box<int> bx(5, 2);
-            cortex::box<bool> bxcheck(5, 2);
-
-            for (auto i { 0ul }; i < v.size(); ++i)
-            {
-                bx[i] = v[i];
-                bxcheck[i] = v[i] > 2;
-            }
+            cortex::box<int> bx(v.begin(), v.end(), 5, 2);
+            cortex::box<bool> bxcheck { { false, false }
+                                      , { false, false }
+                                      , { false, true }
+                                      , { false, true }
+                                      , { false, false } };
 
             auto rbx { bx > 2 };
 
@@ -253,14 +245,12 @@ TEST_CASE("Boolean Masks")
         SECTION("Mismatched")
         {
             std::vector<int> v { 1, 2, 1, 1, 1, 5, 2, 5, 2, 2 };
-            cortex::box<int> bx(5, 2);
-            cortex::box<bool> bxcheck(5, 2);
-
-            for (auto i { 0ul }; i < v.size(); ++i)
-            {
-                bx[i] = v[i];
-                bxcheck[i] = v[i] <= 2;
-            }
+            cortex::box<int> bx(v.begin(), v.end(), 5, 2);
+            cortex::box<bool> bxcheck { { true, true }
+                                      , { true, true }
+                                      , { true, false }
+                                      , { true, false }
+                                      , { true, true } };
 
             auto rbx { bx <= 2 };
 
@@ -310,14 +300,12 @@ TEST_CASE("Boolean Masks")
         SECTION("Mismatched")
         {
             std::vector<int> v { 1, 2, 1, 1, 1, 5, 2, 5, 2, 2 };
-            cortex::box<int> bx(5, 2);
-            cortex::box<bool> bxcheck(5, 2);
-
-            for (auto i { 0ul }; i < v.size(); ++i)
-            {
-                bx[i] = v[i];
-                bxcheck[i] = v[i] >= 2;
-            }
+            cortex::box<int> bx(v.begin(), v.end(), 5, 2);
+            cortex::box<bool> bxcheck { { false, true }
+                                      , { false, false }
+                                      , { false, true }
+                                      , { true, true }
+                                      , { true, true } };
 
             auto rbx { bx >= 2 };
 

--- a/src/test/utility.test.cpp
+++ b/src/test/utility.test.cpp
@@ -10,19 +10,19 @@ TEST_CASE("Utility Functions")
             cortex::box<int> bx(2, 3, 1);
             cortex::box<int> nbx(7, 4, 2);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == 1);
-
-            for (auto i { 0ul }; i < nbx.size(); ++i)
-                REQUIRE(nbx[i] == 2);
+            for (auto& v : bx)
+                REQUIRE(v == 1);
+            
+            for (auto& v : nbx)
+                REQUIRE(v == 2);
 
             bx.swap(nbx);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == 2);
-
-            for (auto i { 0ul }; i < nbx.size(); ++i)
-                REQUIRE(nbx[i] == 1);
+            for (auto& v : bx)
+                REQUIRE(v == 2);
+            
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
 
         SECTION("box - std::swap")
@@ -30,19 +30,19 @@ TEST_CASE("Utility Functions")
             cortex::box<int> bx(2, 3, 1);
             cortex::box<int> nbx(7, 4, 2);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == 1);
-
-            for (auto i { 0ul }; i < nbx.size(); ++i)
-                REQUIRE(nbx[i] == 2);
+            for (auto& v : bx)
+                REQUIRE(v == 1);
+            
+            for (auto& v : nbx)
+                REQUIRE(v == 2);
 
             std::swap(bx, nbx);
 
-            for (auto i { 0ul }; i < bx.size(); ++i)
-                REQUIRE(bx[i] == 2);
-
-            for (auto i { 0ul }; i < nbx.size(); ++i)
-                REQUIRE(nbx[i] == 1);
+            for (auto& v : bx)
+                REQUIRE(v == 2);
+            
+            for (auto& v : nbx)
+                REQUIRE(v == 1);
         }
     }
 


### PR DESCRIPTION
# Release Notes

This release introduced the slice method and slice operator for box. 

## Added:
- box::slice returns a span of the indicated row.
- [] is now used as the slice operator.

## Changes:
- Fixed some old test cases that used previous variation of operator[].
- Generalised and updated the boolean mask test cases.