### PR TITLE
cortexlib v0.12.0 Release [Revision 2]

### DIFF
--- a/bpt.yaml
+++ b/bpt.yaml
@@ -12,17 +12,16 @@ description: |
   A collection of libraries for containers, algorithms, iterators, utilities and more C++20.
 
 
-libraries: 
-  - name: iterators
-    path: libs/iterators
-    test-dependencies: [catch2@2.13.9]
+libraries:
   - name: concepts
     path: libs/concepts
-    test-dependencies: [catch2@2.13.9]
+
+  - name: iterators
+    path: libs/iterators
+
   - name: box
     path: libs/box
-    using: [iterators, concepts]
-    test-dependencies: [catch2@2.13.9]
+    using: [concepts, iterators]
 
 
 repository: https://github.com/oraqlle/cortexlib

--- a/libs/box/src/box.hpp
+++ b/libs/box/src/box.hpp
@@ -23,8 +23,8 @@
 
 #if __cplusplus >= 202002L
 
+#include <algorithm>
 #include <cassert>
-#include <execution>
 #include <functional>
 #include <initializer_list>
 #include <memory>

--- a/libs/box/src/box.hpp
+++ b/libs/box/src/box.hpp
@@ -16,10 +16,10 @@
 #ifndef CORTEX_BOX_H
 #define CORTEX_BOX_H 1
 
-#include "iterators/column.hpp"
-#include "concepts.hpp"
-#include "iterators/normal.hpp"
-#include "iterators/row.hpp"
+#include </home/tyler/dev/cortexlib/libs/concepts/src/concepts.hpp>
+#include <iterators/column.hpp>
+#include <iterators/normal.hpp>
+#include <iterators/row.hpp>
 
 #if __cplusplus >= 202002L
 

--- a/libs/box/src/box.hpp
+++ b/libs/box/src/box.hpp
@@ -16,7 +16,7 @@
 #ifndef CORTEX_BOX_H
 #define CORTEX_BOX_H 1
 
-#include </home/tyler/dev/cortexlib/libs/concepts/src/concepts.hpp>
+#include <concepts.hpp>
 #include <iterators/column.hpp>
 #include <iterators/normal.hpp>
 #include <iterators/row.hpp>

--- a/libs/concepts/src/concepts.hpp
+++ b/libs/concepts/src/concepts.hpp
@@ -1,4 +1,4 @@
-/// -*- C++ -*- Header compatiability <concpets.hpp>
+/// -*- C++ -*- Header compatiability <concepts.hpp>
 
 /// \brief Some generalised concepts for use throughout
 /// the Cortex Library
@@ -28,7 +28,6 @@ namespace cortex
     /// \details A concept for which any type is valid.
     /// 
     /// \tparam _Tp 
-    
     template<typename _Tp>
     concept Any = true;
 
@@ -38,7 +37,6 @@ namespace cortex
     /// \details A concept for which no type is valid.
     /// 
     /// \tparam _Tp 
-    
     template<typename _Tp>
     concept None = false;
 
@@ -50,7 +48,6 @@ namespace cortex
     /// is a number.
     /// 
     /// \tparam _Tp 
-    
     template<typename _Tp>
     concept Number = std::integral<_Tp> || std::floating_point<_Tp>;
 
@@ -61,7 +58,6 @@ namespace cortex
     /// concept for a type that is an object.
     /// 
     /// \tparam _Tp 
-    
     template<typename _Tp>
     concept Object = std::is_object_v<_Tp>;
     

--- a/xbuild.yaml
+++ b/xbuild.yaml
@@ -1,0 +1,9 @@
+# Work in progress build toolchain for 
+# C++ circle compiler with bpt.
+
+compiler_id: circle
+
+cxx_version: c++20
+
+flags:
+  - 


### PR DESCRIPTION
# Release Notes

Due to some link errors, v0.12.0 have been re-released but now can be confirmed to work. Have a look at the original release notes for content changes made.