### PR TITLE
Patch Release v0.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ _deps/*
 *.exe
 *.out
 *.app
+
+# Text Files
+*.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![bpt Version](https://img.shields.io/badge/bpt%20version%3A-1.0.0--beta--1-blue)
 ![C++ Standard](https://img.shields.io/badge/C%2B%2B%20Standard-C%2B%2B20-red)
 ![GCC](https://img.shields.io/badge/GCC-11.1.0-yellow)
-![Clang](https://img.shields.io/badge/clang-12.0.0-yellow)
+![Clang](https://img.shields.io/badge/clang-10.0.0-yellow)
 
 ## Welcome
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![bpt Version](https://img.shields.io/badge/bpt%20version%3A-1.0.0--beta--1-blue)
 ![C++ Standard](https://img.shields.io/badge/C%2B%2B%20Standard-C%2B%2B20-red)
 ![GCC](https://img.shields.io/badge/GCC-11.1.0-yellow)
-![Clang](https://img.shields.io/badge/clang-❌-yellow)
+![Clang](https://img.shields.io/badge/clang-12.0.0-yellow)
 
 ## Welcome
 

--- a/bpt.yaml
+++ b/bpt.yaml
@@ -1,5 +1,5 @@
 name: cortexlib
-version: 0.12.0
+version: 0.12.1
 
 test-dependencies:
   - catch2@2.13.9 using main

--- a/libs/box/src/box.hpp
+++ b/libs/box/src/box.hpp
@@ -2087,6 +2087,7 @@ namespace cortex
         constexpr size_type _M_size(size_type __rows, size_type __columns) const noexcept
         { return __rows * __columns != 0 ? __rows * __columns : std::max(__rows, __columns); }
 
+
         constexpr size_type _M_index(size_type __row, size_type __column) const noexcept
         { return __row * columns() + __column; }
 

--- a/libs/box/src/box.hpp
+++ b/libs/box/src/box.hpp
@@ -28,7 +28,6 @@
 #include <functional>
 #include <initializer_list>
 #include <memory>
-#include <ranges>
 #include <span>
 #include <utility>
 #include <vector>

--- a/libs/box/src/tests/iterators.test.cpp
+++ b/libs/box/src/tests/iterators.test.cpp
@@ -49,7 +49,9 @@ TEST_CASE("Iterators")
             cortex::box<int> bx = { { 1, 2 }
                                   , { 3, 4 } };
 
-            for (auto v { 4 }; auto& elem : bx | std::views::reverse)
+            std::reverse(bx.begin(), bx.end());
+
+            for (auto v { 4 }; auto& elem : bx)
             
                 REQUIRE(elem == v--);
         }
@@ -61,14 +63,19 @@ TEST_CASE("Iterators")
             std::iota(bx.begin(), bx.end(), 1);
 
             auto value { 20 };
-            for (auto& elem : bx | std::views::reverse)
+            std::reverse(bx.begin(), bx.end());
+
+            for (auto& elem : bx)
             {
                 REQUIRE(elem == value--);
                 elem *= 2;
             }
 
             value = 20;
-            for (auto& elem : bx | std::views::reverse)
+            std::reverse(bx.begin(), bx.end());
+            std::reverse(bx.begin(), bx.end());
+            
+            for (auto& elem : bx)
                 REQUIRE(elem == 2 * value--);
         }
     }

--- a/libs/iterators/src/tests/enumerate.test.cpp
+++ b/libs/iterators/src/tests/enumerate.test.cpp
@@ -8,7 +8,7 @@ TEST_CASE("Basic Enumeration")
     
     for (auto [i, e] : v | cortex::adaptors::enumerate(0))
     {
-        REQUIRE(e == v[i]);
+        REQUIRE(e == v[std::size_t(i)]);
     }
 }
 
@@ -57,6 +57,6 @@ TEST_CASE("Eliding the Adaptor Namespace")
     
     for (auto [i, e] : v | enumerate(0))
     {
-        REQUIRE(e == v[i]);
+        REQUIRE(e == v[std::size_t(i)]);
     }
 }


### PR DESCRIPTION
## Release Notes

Removed <ranges> header as it was causing build issues with clang. `cortexlib` can now be compiled with clang v10.0.0 - v13.0.0.

## Note 
clang produces many warnings, mostly about implicit conversions. These can be ignored for the most part for now.