### PR TITLE
Major release: v1.0.0

### DIFF
--- a/bpt.yaml
+++ b/bpt.yaml
@@ -1,5 +1,5 @@
 name: cortexlib
-version: 0.2.0
+version: 1.0.0
 
 test-dependencies:
   - catch2@2.13.9 using main

--- a/include/containers/matrix.hxx
+++ b/include/containers/matrix.hxx
@@ -171,7 +171,7 @@ namespace cxl
             : m_num_rows{ other.m_num_rows }
             , m_num_columns{ other.m_num_columns }
             , m_allocator{ alloc }
-            , m_start{ _M_allocate(_M_size_check(num_rows, num_columns)) }
+            , m_start{ _M_allocate(_M_size_check(other.m_num_rows, other.m_num_columns)) }
             , m_finish{ m_start + size() }
         { std::ranges::uninitialized_copy(other, *this); }
 

--- a/src/containers/matrix.test.cxx
+++ b/src/containers/matrix.test.cxx
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 #include <fmt/core.h>
 
-#include <data_structures/matrix.hxx>
+#include <containers/matrix.hxx>
 
 #include <iostream>
 #include <numeric>


### PR DESCRIPTION
## Changes

Fixed include paths for matrix tests
Fixed name bug (clang)
Major version bump (v1.0.0)